### PR TITLE
[WP8] fix resume for DrawingSurfaceBackgroundGrid

### DIFF
--- a/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
@@ -156,10 +156,17 @@ namespace Microsoft.Xna.Framework.Graphics
         private void UpdateDevice(Device device, DeviceContext context)
         {
             // TODO: Lost device logic!
-            SharpDX.Utilities.Dispose(ref _d3dDevice);
-            _d3dDevice = device;
+            if (WindowsPhoneGameWindow.IsUsingDrawingSurfaceBackgroundGrid)
+            {
+			    context.ClearState();
+            }
+            else
+            {
+                SharpDX.Utilities.Dispose(ref _d3dDevice);
+                SharpDX.Utilities.Dispose(ref _d3dContext);
+            }
 
-            SharpDX.Utilities.Dispose(ref _d3dContext);
+            _d3dDevice = device;
             _d3dContext = context;
 
             SharpDX.Utilities.Dispose(ref _depthStencilView);

--- a/MonoGame.Framework/WindowsPhone/WPGameWindow.cs
+++ b/MonoGame.Framework/WindowsPhone/WPGameWindow.cs
@@ -60,6 +60,7 @@ namespace MonoGame.Framework.WindowsPhone
 
         #region Internal Properties
 
+        static internal bool IsUsingDrawingSurfaceBackgroundGrid;
         static internal double Width;
         static internal double Height;
         static internal PhoneApplicationPage Page;

--- a/MonoGame.Framework/WindowsPhone/XamlGame.cs
+++ b/MonoGame.Framework/WindowsPhone/XamlGame.cs
@@ -116,6 +116,8 @@ namespace MonoGame.Framework.WindowsPhone
             if (page == null)
                 throw new NullReferenceException("The page parameter cannot be null!");
 
+            WindowsPhoneGameWindow.IsUsingDrawingSurfaceBackgroundGrid = (page.Content is DrawingSurfaceBackgroundGrid);
+
             UIElement drawingSurface = page.Content as DrawingSurfaceBackgroundGrid;
             
             MediaElement mediaElement = null;


### PR DESCRIPTION
When DrawingSurfaceBackgroundGrid is used we don't won the
_d3device/_d3dContext, it's provided by
IDrawingSurfaceBackgroundContentProviderNative.
Trying to dispose the previous device/context thows a
System.NullReferenceException and resume result to a black
screen/freeze.