### PR TITLE
[UAP] Alternative RenderLoop

### DIFF
--- a/MonoGame.Framework/WindowsUniversal/UAPGamePlatform.cs
+++ b/MonoGame.Framework/WindowsUniversal/UAPGamePlatform.cs
@@ -132,13 +132,19 @@ namespace Microsoft.Xna.Framework
 
         public override void StartRunLoop()
         {
-            CompositionTarget.Rendering += (o, a) =>
-            {
-				UAPGameWindow.Instance.Tick();
-                GamePad.Back = false;
-            };
+            CoreWindow.GetForCurrentThread().Dispatcher.RunIdleAsync(OnRenderFrame);
         }
         
+        private void OnRenderFrame(IdleDispatchedHandlerArgs e)
+        {                
+            UAPGameWindow.Instance.Tick();
+            GamePad.Back = false;
+
+            // Request next frame
+            if (!UAPGameWindow.Instance.IsExiting)
+                CoreWindow.GetForCurrentThread().Dispatcher.RunIdleAsync(OnRenderFrame);
+        }
+
         public override void Exit()
         {
             if (!UAPGameWindow.Instance.IsExiting)


### PR DESCRIPTION
Use Idle for Tick(). Let Dispatcher process all events (input/resize/rotate) before rendering.