### PR TITLE
Implemention of GraphicsContext

### DIFF
--- a/Build/Projects/MonoGame.Framework.definition
+++ b/Build/Projects/MonoGame.Framework.definition
@@ -605,7 +605,7 @@
       <Services>WebGraphics</Services>
     </Compile>
     <Compile Include="Graphics\GraphicsContext.cs">
-      <Services>DirectXGraphics,OpenGLGraphics</Services>
+      <Services>DirectXGraphics,OpenGLGraphics,WebGraphics</Services>
     </Compile>
     <Compile Include="Graphics\GraphicsContext.DirectX.cs">
       <Services>DirectXGraphics</Services>
@@ -616,6 +616,9 @@
     </Compile>
     <Compile Include="Graphics\GraphicsContext.SDL.cs">
       <Platforms>WindowsGL,Linux</Platforms>
+    </Compile>
+    <Compile Include="Graphics\GraphicsContext.Web.cs">
+      <Services>WebGraphics</Services>
     </Compile>
     <Compile Include="Graphics\GraphicsDevice.cs" />
     <Compile Include="Graphics\GraphicsDevice.DirectX.cs">

--- a/Build/Projects/MonoGame.Framework.definition
+++ b/Build/Projects/MonoGame.Framework.definition
@@ -604,6 +604,12 @@
     <Compile Include="Graphics\GraphicsCapabilities.Web.cs">
       <Services>WebGraphics</Services>
     </Compile>
+    <Compile Include="Graphics\GraphicsContext.cs">
+      <Services>DirectXGraphics</Services>
+    </Compile>
+    <Compile Include="Graphics\GraphicsContext.DirectX.cs">
+      <Services>DirectXGraphics</Services>
+    </Compile>
     <Compile Include="Graphics\GraphicsContext.SDL.cs">
       <Platforms>WindowsGL,Linux</Platforms>
     </Compile>

--- a/Build/Projects/MonoGame.Framework.definition
+++ b/Build/Projects/MonoGame.Framework.definition
@@ -604,9 +604,7 @@
     <Compile Include="Graphics\GraphicsCapabilities.Web.cs">
       <Services>WebGraphics</Services>
     </Compile>
-    <Compile Include="Graphics\GraphicsContext.cs">
-      <Services>DirectXGraphics,OpenGLGraphics,WebGraphics</Services>
-    </Compile>
+    <Compile Include="Graphics\GraphicsContext.cs" />
     <Compile Include="Graphics\GraphicsContext.DirectX.cs">
       <Services>DirectXGraphics</Services>
     </Compile>

--- a/Build/Projects/MonoGame.Framework.definition
+++ b/Build/Projects/MonoGame.Framework.definition
@@ -605,10 +605,14 @@
       <Services>WebGraphics</Services>
     </Compile>
     <Compile Include="Graphics\GraphicsContext.cs">
-      <Services>DirectXGraphics</Services>
+      <Services>DirectXGraphics,OpenGLGraphics</Services>
     </Compile>
     <Compile Include="Graphics\GraphicsContext.DirectX.cs">
       <Services>DirectXGraphics</Services>
+    </Compile>
+    <Compile Include="Graphics\GraphicsContext.OpenGL.cs">
+      <ExcludePlatforms>WindowsGL,Linux</ExcludePlatforms>
+      <Services>OpenGLGraphics</Services>
     </Compile>
     <Compile Include="Graphics\GraphicsContext.SDL.cs">
       <Platforms>WindowsGL,Linux</Platforms>

--- a/Build/Projects/MonoGame.Tests.definition
+++ b/Build/Projects/MonoGame.Tests.definition
@@ -122,6 +122,9 @@
     <Compile Include="Framework\Audio\SoundEffectTest.cs" />
     <Compile Include="Framework\Audio\XactTest.cs" />
     <Compile Include="Framework\Audio\DynamicSoundEffectInstanceTest.cs" />
+    <Compile Include="Framework\Audio\SoundEffectInstanceXAudioTest.cs">
+        <Platforms>Windows</Platforms>
+    </Compile>
 
     <Compile Include="Framework\Components\DrawFrameNumberComponent.cs" />
     <Compile Include="Framework\Components\FlexibleGameComponent.cs" />

--- a/MonoGame.Framework/Audio/SoundEffect.XAudio.cs
+++ b/MonoGame.Framework/Audio/SoundEffect.XAudio.cs
@@ -282,9 +282,12 @@ namespace Microsoft.Xna.Framework.Audio
             }
 
             if (voice == null && Device != null)
+            {
                 voice = new SourceVoice(Device, _format, VoiceFlags.UseFilter, XAudio2.MaximumFrequencyRatio);
+                inst._voice = voice;
+                inst.UpdateOutputMatrix(); // Ensure the output matrix is set for this new voice
+            }
 
-            inst._voice = voice;
             inst._format = _format;
         }
 

--- a/MonoGame.Framework/Graphics/GraphicsContext.DirectX.cs
+++ b/MonoGame.Framework/Graphics/GraphicsContext.DirectX.cs
@@ -3,6 +3,7 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
+using SharpDX;
 using SharpDX.Direct3D11;
 
 namespace Microsoft.Xna.Framework.Graphics
@@ -17,6 +18,31 @@ namespace Microsoft.Xna.Framework.Graphics
             this._d3dContext = deviceContext;
         }
         
+        internal void PlatformApplyBlend(bool force)
+        {   
+            var state = _actualBlendState.GetDxState(_device);
+            var factor = GetBlendFactor();
+            _d3dContext.OutputMerger.SetBlendState(state, factor);
+        }
+
+
+
+#if WINDOWS_UAP
+        private SharpDX.Mathematics.Interop.RawColor4 GetBlendFactor()
+        {
+			return new SharpDX.Mathematics.Interop.RawColor4(
+					BlendFactor.R / 255.0f,
+					BlendFactor.G / 255.0f,
+					BlendFactor.B / 255.0f,
+					BlendFactor.A / 255.0f);
+        }
+#else
+        private Color4 GetBlendFactor()
+        {
+			return BlendFactor.ToColor4();
+        }
+#endif
+
         #region Implement IDisposable
         private void PlatformDispose(bool disposing)
         {            

--- a/MonoGame.Framework/Graphics/GraphicsContext.DirectX.cs
+++ b/MonoGame.Framework/Graphics/GraphicsContext.DirectX.cs
@@ -1,0 +1,35 @@
+﻿// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+using System;
+using SharpDX.Direct3D11;
+
+namespace Microsoft.Xna.Framework.Graphics
+{
+    internal partial class GraphicsContext : IDisposable
+    {
+        internal DeviceContext _d3dContext;
+
+        public GraphicsContext(GraphicsDevice device, DeviceContext deviceContext)
+        {
+            Initialize(device);
+            this._d3dContext = deviceContext;
+        }
+        
+        #region Implement IDisposable
+        private void PlatformDispose(bool disposing)
+        {            
+            if (disposing)
+            {
+                // Release managed objects
+                // ...
+            }
+
+            // Release native objects
+            SharpDX.Utilities.Dispose(ref _d3dContext);            
+        }
+        #endregion
+    }
+    
+}

--- a/MonoGame.Framework/Graphics/GraphicsContext.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/GraphicsContext.OpenGL.cs
@@ -1,0 +1,31 @@
+﻿// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+using System;
+
+namespace Microsoft.Xna.Framework.Graphics
+{
+    internal partial class GraphicsContext : IDisposable
+    {
+        public GraphicsContext(GraphicsDevice device)
+        {
+            Initialize(device);
+        }
+        
+        #region Implement IDisposable
+        private void PlatformDispose(bool disposing)
+        {            
+            if (disposing)
+            {
+                // Release managed objects
+                // ...
+            }
+
+            // Release native objects
+            // ...          
+        }
+        #endregion
+    }
+    
+}

--- a/MonoGame.Framework/Graphics/GraphicsContext.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/GraphicsContext.OpenGL.cs
@@ -4,15 +4,64 @@
 
 using System;
 
+#if MONOMAC
+#if PLATFORM_MACOS_LEGACY
+using MonoMac.OpenGL;
+using GLPrimitiveType = MonoMac.OpenGL.BeginMode;
+#else
+using OpenTK.Graphics.OpenGL;
+using GLPrimitiveType = OpenTK.Graphics.OpenGL.BeginMode;
+#endif
+#endif
+
+#if DESKTOPGL
+using OpenGL;
+#endif
+
+#if ANGLE
+using OpenTK.Graphics;
+#endif
+
+#if GLES
+using OpenTK.Graphics.ES20;
+using FramebufferAttachment = OpenTK.Graphics.ES20.All;
+using RenderbufferStorage = OpenTK.Graphics.ES20.All;
+using GLPrimitiveType = OpenTK.Graphics.ES20.BeginMode;
+#endif
+
 namespace Microsoft.Xna.Framework.Graphics
 {
     internal partial class GraphicsContext : IDisposable
     {
+        // Keeps track of last applied state to avoid redundant OpenGL calls
+        internal BlendState _lastBlendState = new BlendState();
+        internal bool _lastBlendEnable = false;
+
         public GraphicsContext(GraphicsDevice device)
         {
             Initialize(device);
         }
         
+
+        private void PlatformApplyBlend(bool force = false)
+        {
+            _actualBlendState.PlatformApplyState(_device, force);
+            ApplyBlendFactor(force);
+        }
+
+        private void ApplyBlendFactor(bool force)
+        {
+            if (force || BlendFactor != _lastBlendState.BlendFactor)
+            {
+                GL.BlendColor(
+                    this.BlendFactor.R/255.0f,
+                    this.BlendFactor.G/255.0f,
+                    this.BlendFactor.B/255.0f,
+                    this.BlendFactor.A/255.0f);
+                GraphicsExtensions.CheckGLError();
+                _lastBlendState.BlendFactor = this.BlendFactor;
+            }
+        }
         #region Implement IDisposable
         private void PlatformDispose(bool disposing)
         {            
@@ -23,9 +72,8 @@ namespace Microsoft.Xna.Framework.Graphics
             }
 
             // Release native objects
-            // ...          
+            // ...
         }
         #endregion
     }
-    
 }

--- a/MonoGame.Framework/Graphics/GraphicsContext.SDL.cs
+++ b/MonoGame.Framework/Graphics/GraphicsContext.SDL.cs
@@ -3,14 +3,14 @@
 // file 'LICENSE.txt', which is part of this source code package.
 
 using System;
+using OpenGL;
 
-namespace OpenGL
+namespace Microsoft.Xna.Framework.Graphics
 {
-    public class GraphicsContext : IGraphicsContext, IDisposable
+    internal partial class GraphicsContext : IGraphicsContext, IDisposable
     {
         private IntPtr _context;
         private IntPtr _winHandle;
-        private bool _disposed;
 
         public int SwapInterval
         {
@@ -29,10 +29,9 @@ namespace OpenGL
             get { return _disposed; }
         }
 
-        public GraphicsContext(IWindowInfo info)
+        public GraphicsContext(GraphicsDevice device, IWindowInfo info)
         {
-            if (_disposed)
-                return;
+            Initialize(device);
             
             SetWindowHandle(info);
             _context = Sdl.GL.CreateContext(_winHandle);
@@ -50,6 +49,16 @@ namespace OpenGL
             }
         }
 
+
+        private void SetWindowHandle(IWindowInfo info)
+        {
+            if (info == null)
+                _winHandle = IntPtr.Zero;
+            else
+                _winHandle = info.Handle;
+        }
+
+        #region Implement IGraphicsContext
         public void MakeCurrent(IWindowInfo info)
         {
             if (_disposed)
@@ -67,21 +76,20 @@ namespace OpenGL
             Sdl.GL.SwapWindow(_winHandle);
         }
 
-        public void Dispose()
-        {
-            if (_disposed)
-                return;
-            
-            Sdl.GL.DeleteContext(_context);
-            _disposed = true;
-        }
+        #endregion
+        
+        #region Implement IDisposable
+        private void PlatformDispose(bool disposing)
+        {            
+            if (disposing)
+            {
+                // Release managed objects
+                // ...
+            }
 
-        private void SetWindowHandle(IWindowInfo info)
-        {
-            if (info == null)
-                _winHandle = IntPtr.Zero;
-            else
-                _winHandle = info.Handle;
+            // Release native objects
+            Sdl.GL.DeleteContext(_context);
         }
+        #endregion
     }
 }

--- a/MonoGame.Framework/Graphics/GraphicsContext.SDL.cs
+++ b/MonoGame.Framework/Graphics/GraphicsContext.SDL.cs
@@ -12,6 +12,9 @@ namespace Microsoft.Xna.Framework.Graphics
         private IntPtr _context;
         private IntPtr _winHandle;
 
+        // Keeps track of last applied state to avoid redundant OpenGL calls
+        internal BlendState _lastBlendState = new BlendState();
+
         public int SwapInterval
         {
             get
@@ -58,6 +61,27 @@ namespace Microsoft.Xna.Framework.Graphics
                 _winHandle = info.Handle;
         }
 
+        private void PlatformApplyBlend(bool force = false)
+        {
+            _actualBlendState.PlatformApplyState(_device, force);
+            ApplyBlendFactor(force);
+        }
+
+        private void ApplyBlendFactor(bool force)
+        {
+            if (force || BlendFactor != _lastBlendState.BlendFactor)
+            {
+                GL.BlendColor(
+                    this.BlendFactor.R/255.0f,
+                    this.BlendFactor.G/255.0f,
+                    this.BlendFactor.B/255.0f,
+                    this.BlendFactor.A/255.0f);
+                GraphicsExtensions.CheckGLError();
+                _lastBlendState.BlendFactor = this.BlendFactor;
+            }
+        }
+
+        
         #region Implement IGraphicsContext
         public void MakeCurrent(IWindowInfo info)
         {

--- a/MonoGame.Framework/Graphics/GraphicsContext.Web.cs
+++ b/MonoGame.Framework/Graphics/GraphicsContext.Web.cs
@@ -1,0 +1,31 @@
+﻿// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+using System;
+
+namespace Microsoft.Xna.Framework.Graphics
+{
+    internal partial class GraphicsContext : IDisposable
+    {
+        public GraphicsContext(GraphicsDevice device)
+        {
+            Initialize(device);
+        }
+        
+        #region Implement IDisposable
+        private void PlatformDispose(bool disposing)
+        {            
+            if (disposing)
+            {
+                // Release managed objects
+                // ...
+            }
+
+            // Release native objects
+            // ...          
+        }
+        #endregion
+    }
+    
+}

--- a/MonoGame.Framework/Graphics/GraphicsContext.cs
+++ b/MonoGame.Framework/Graphics/GraphicsContext.cs
@@ -1,0 +1,43 @@
+﻿// MonoGame - Copyright (C) The MonoGame Team
+// This file is subject to the terms and conditions defined in
+// file 'LICENSE.txt', which is part of this source code package.
+
+using System;
+
+namespace Microsoft.Xna.Framework.Graphics
+{
+    internal partial class GraphicsContext : IDisposable
+    {
+        private bool _disposed = false;
+
+        private GraphicsDevice _device;
+        
+        private void Initialize(GraphicsDevice device)
+        {
+            _device = device;
+        }
+        
+        ~GraphicsContext()
+        {
+            Dispose(false);
+        }
+
+        #region Implement IDisposable
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!_disposed)
+            {
+                PlatformDispose(disposing);
+                _device = null;
+                _disposed = true;
+            }
+        }
+        #endregion
+    }    
+}

--- a/MonoGame.Framework/Graphics/GraphicsContext.cs
+++ b/MonoGame.Framework/Graphics/GraphicsContext.cs
@@ -12,14 +12,104 @@ namespace Microsoft.Xna.Framework.Graphics
 
         private GraphicsDevice _device;
         
+        private Color _blendFactor = Color.White;
+        private bool _blendFactorDirty;
+        
+        private BlendState _blendState;    
+        private BlendState _actualBlendState;
+        internal bool _blendStateDirty;
+        
+        private BlendState _blendStateAdditive;
+        private BlendState _blendStateAlphaBlend;
+        private BlendState _blendStateNonPremultiplied;
+        private BlendState _blendStateOpaque;
+
         private void Initialize(GraphicsDevice device)
         {
             _device = device;
+                        
+            _blendStateAdditive = BlendState.Additive.Clone();
+            _blendStateAlphaBlend = BlendState.AlphaBlend.Clone();
+            _blendStateNonPremultiplied = BlendState.NonPremultiplied.Clone();
+            _blendStateOpaque = BlendState.Opaque.Clone();
         }
         
         ~GraphicsContext()
         {
             Dispose(false);
+        }
+
+        internal void SetDefaultRenderStates()
+        {
+            _blendStateDirty = true;
+            BlendState = BlendState.Opaque;
+        }
+        
+        /// <summary>
+        /// The color used as blend factor when alpha blending.
+        /// </summary>
+        /// <remarks>
+        /// When only changing BlendFactor, use this rather than <see cref="Graphics.BlendState.BlendFactor"/> to
+        /// only update BlendFactor so the whole BlendState does not have to be updated.
+        /// </remarks>
+        public Color BlendFactor
+        {
+            get { return _blendFactor; }
+            set
+            {
+                if (_blendFactor == value)
+                    return;
+                _blendFactor = value;
+                _blendFactorDirty = true;
+            }
+        }
+        
+        public BlendState BlendState
+        {
+			get { return _blendState; }
+			set
+            {
+                if (value == null)
+                    throw new ArgumentNullException("value");
+
+                // Don't set the same state twice!
+                if (_blendState == value)
+                    return;
+
+				_blendState = value;
+
+                // Static state properties never actually get bound;
+                // instead we use our GraphicsDevice-specific version of them.
+                var newBlendState = _blendState;
+                if (ReferenceEquals(_blendState, BlendState.Additive))
+                    newBlendState = _blendStateAdditive;
+                else if (ReferenceEquals(_blendState, BlendState.AlphaBlend))
+                    newBlendState = _blendStateAlphaBlend;
+                else if (ReferenceEquals(_blendState, BlendState.NonPremultiplied))
+                    newBlendState = _blendStateNonPremultiplied;
+                else if (ReferenceEquals(_blendState, BlendState.Opaque))
+                    newBlendState = _blendStateOpaque;
+
+                // Blend state is now bound to a device... no one should
+                // be changing the state of the blend state object now!
+                newBlendState.BindToGraphicsDevice(_device);
+
+                _actualBlendState = newBlendState;
+
+                BlendFactor = _actualBlendState.BlendFactor;
+
+                _blendStateDirty = true;
+            }
+		}
+
+        internal void ApplyBlend(bool force = false)
+        {
+            if (force || _blendFactorDirty || _blendStateDirty)
+            {
+                PlatformApplyBlend(force);
+                _blendFactorDirty = false;
+                _blendStateDirty = false;
+            }
         }
 
         #region Implement IDisposable
@@ -38,6 +128,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 _disposed = true;
             }
         }
+
         #endregion
     }    
 }

--- a/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Xna.Framework.Graphics
     {
         // Core Direct3D Objects
         internal SharpDX.Direct3D11.Device _d3dDevice;
-        private SharpDX.Direct3D11.DeviceContext _d3dContext;
+        private GraphicsContext _context;
         internal SharpDX.Direct3D11.RenderTargetView _renderTargetView;
         internal SharpDX.Direct3D11.DepthStencilView _depthStencilView;
         private int _vertexBufferSlotsUsed;
@@ -96,8 +96,8 @@ namespace Microsoft.Xna.Framework.Graphics
         }
 
 #endif
-
-        internal SharpDX.Direct3D11.DeviceContext Context { get { return _graphicsContext._d3dContext; } }
+        
+        internal GraphicsContext Context { get { return _context; } }
 
         /// <summary>
         /// Returns a handle to internal device object. Valid only on DirectX platforms.
@@ -158,8 +158,8 @@ namespace Microsoft.Xna.Framework.Graphics
             SharpDX.Utilities.Dispose(ref _d3dDevice);
             _d3dDevice = device;
 
-            SharpDX.Utilities.Dispose(ref _d3dContext);
-            _d3dContext = context;
+            _context.Dispose();
+            _context = new GraphicsContext(this, context);
 
             SharpDX.Utilities.Dispose(ref _depthStencilView);
 
@@ -255,8 +255,8 @@ namespace Microsoft.Xna.Framework.Graphics
             // Dispose previous references.
             if (_d3dDevice != null)
                 _d3dDevice.Dispose();
-            if (_d3dContext != null)
-                _d3dContext.Dispose();
+            if (_context != null)
+                _context.Dispose();
             if (_d2dDevice != null)
                 _d2dDevice.Dispose();
             if (_d2dContext != null)
@@ -308,7 +308,7 @@ namespace Microsoft.Xna.Framework.Graphics
 #endif
 
             // Get Direct3D 11.1 context
-            _d3dContext = _d3dDevice.ImmediateContext.QueryInterface<SharpDX.Direct3D11.DeviceContext1>();
+            _context = new GraphicsContext(this, _d3dDevice.ImmediateContext.QueryInterface<SharpDX.Direct3D11.DeviceContext1>());
 
             // Create the Direct2D device.
             using (var dxgiDevice = _d3dDevice.QueryInterface<SharpDX.DXGI.Device>())
@@ -583,8 +583,8 @@ namespace Microsoft.Xna.Framework.Graphics
             // Dispose previous references.
             if (_d3dDevice != null)
                 _d3dDevice.Dispose();
-            if (_d3dContext != null)
-                _d3dContext.Dispose();
+            if (_context != null)
+                _context.Dispose();
 
             // Windows requires BGRA support out of DX.
             var creationFlags = SharpDX.Direct3D11.DeviceCreationFlags.BgraSupport;
@@ -652,7 +652,7 @@ namespace Microsoft.Xna.Framework.Graphics
 #endif
 
             // Get Direct3D 11.1 context
-            _d3dContext = _d3dDevice.ImmediateContext.QueryInterface<SharpDX.Direct3D11.DeviceContext>();
+            _context = new GraphicsContext(this, _d3dDevice.ImmediateContext.QueryInterface<SharpDX.Direct3D11.DeviceContext>());
         }
 
         private int GetMultiSamplingQuality(Format format, int multiSampleCount)
@@ -668,7 +668,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
         internal void CreateSizeDependentResources()
         {
-            Context.OutputMerger.SetTargets((SharpDX.Direct3D11.DepthStencilView)null,
+            Context._d3dContext.OutputMerger.SetTargets((SharpDX.Direct3D11.DepthStencilView)null,
                                                    (SharpDX.Direct3D11.RenderTargetView)null);
 
             if (_renderTargetView != null)
@@ -689,7 +689,7 @@ namespace Microsoft.Xna.Framework.Graphics
             _currentRenderTargetCount = 0;
 
             // Make sure all pending rendering commands are flushed.
-            Context.Flush();
+            Context._d3dContext.Flush();
 
             // We need presentation parameters to continue here.
             if (PresentationParameters == null || PresentationParameters.DeviceWindowHandle == IntPtr.Zero)
@@ -848,7 +848,7 @@ namespace Microsoft.Xna.Framework.Graphics
 #if WINDOWS_UAP
 							Context.ClearRenderTargetView(view, new RawColor4(color.X, color.Y, color.Z, color.W));
 #else
-                            Context.ClearRenderTargetView(view, new Color4(color.X, color.Y, color.Z, color.W));
+                            Context._d3dContext.ClearRenderTargetView(view, new Color4(color.X, color.Y, color.Z, color.W));
 #endif
                     }
                 }
@@ -861,7 +861,7 @@ namespace Microsoft.Xna.Framework.Graphics
                     flags |= SharpDX.Direct3D11.DepthStencilClearFlags.Stencil;
 
                 if (flags != 0)
-                    Context.ClearDepthStencilView(_currentDepthStencilView, flags, depth, (byte)stencil);
+                    Context._d3dContext.ClearDepthStencilView(_currentDepthStencilView, flags, depth, (byte)stencil);
             }
         }
 
@@ -870,7 +870,7 @@ namespace Microsoft.Xna.Framework.Graphics
             SharpDX.Utilities.Dispose(ref _renderTargetView);
             SharpDX.Utilities.Dispose(ref _depthStencilView);
             SharpDX.Utilities.Dispose(ref _d3dDevice);
-            SharpDX.Utilities.Dispose(ref _d3dContext);
+            _context.Dispose();
 
             if (_userIndexBuffer16 != null)
                 _userIndexBuffer16.Dispose();
@@ -989,7 +989,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 var viewport = new SharpDX.ViewportF(_viewport.X, _viewport.Y, (float)_viewport.Width, (float)_viewport.Height, _viewport.MinDepth, _viewport.MaxDepth);
 #endif
                 lock (Context)
-                    Context.Rasterizer.SetViewport(viewport);
+                    Context._d3dContext.Rasterizer.SetViewport(viewport);
             }
         }
 
@@ -1022,7 +1022,7 @@ namespace Microsoft.Xna.Framework.Graphics
             _currentDepthStencilView = _depthStencilView;
 
             lock (Context)
-                Context.OutputMerger.SetTargets(_currentDepthStencilView, _currentRenderTargets);
+                Context._d3dContext.OutputMerger.SetTargets(_currentDepthStencilView, _currentRenderTargets);
         }
 
         internal void PlatformResolveRenderTargets()
@@ -1036,7 +1036,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 if (renderTargetBinding.RenderTarget.LevelCount > 1)
                 {
                     lock (Context)
-                        Context.GenerateMips(renderTargetBinding.RenderTarget.GetShaderResourceView());
+                        Context._d3dContext.GenerateMips(renderTargetBinding.RenderTarget.GetShaderResourceView());
                 }
             }
         }
@@ -1068,7 +1068,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
             // Set the targets.
             lock (Context)
-                Context.OutputMerger.SetTargets(_currentDepthStencilView, _currentRenderTargets);
+                Context._d3dContext.OutputMerger.SetTargets(_currentDepthStencilView, _currentRenderTargets);
 
             return renderTarget;
         }
@@ -1141,7 +1141,7 @@ namespace Microsoft.Xna.Framework.Graphics
             {
                 var state = _actualBlendState.GetDxState(this);
                 var factor = GetBlendFactor();
-                Context.OutputMerger.SetBlendState(state, factor);
+                Context._d3dContext.OutputMerger.SetBlendState(state, factor);
 
                 _blendFactorDirty = false;
                 _blendStateDirty = false;
@@ -1170,7 +1170,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
             if (_scissorRectangleDirty)
             {
-                Context.Rasterizer.SetScissorRectangle(
+                Context._d3dContext.Rasterizer.SetScissorRectangle(
                     _scissorRectangle.X,
                     _scissorRectangle.Y,
                     _scissorRectangle.Right,
@@ -1186,7 +1186,7 @@ namespace Microsoft.Xna.Framework.Graphics
             {
                 if (_indexBuffer != null)
                 {
-                    Context.InputAssembler.SetIndexBuffer(
+                    Context._d3dContext.InputAssembler.SetIndexBuffer(
                         _indexBuffer.Buffer,
                         _indexBuffer.IndexElementSize == IndexElementSize.SixteenBits ?
                             SharpDX.DXGI.Format.R16_UInt : SharpDX.DXGI.Format.R32_UInt,
@@ -1206,7 +1206,7 @@ namespace Microsoft.Xna.Framework.Graphics
                         var vertexDeclaration = vertexBuffer.VertexDeclaration;
                         int vertexStride = vertexDeclaration.VertexStride;
                         int vertexOffsetInBytes = vertexBufferBinding.VertexOffset * vertexStride;
-                        Context.InputAssembler.SetVertexBuffers(
+                        Context._d3dContext.InputAssembler.SetVertexBuffers(
                             slot, new SharpDX.Direct3D11.VertexBufferBinding(vertexBuffer.Buffer, vertexStride, vertexOffsetInBytes));
                     }
                     _vertexBufferSlotsUsed = _vertexBuffers.Count;
@@ -1214,7 +1214,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 else
                 {
                     for (int slot = 0; slot < _vertexBufferSlotsUsed; slot++)
-                        Context.InputAssembler.SetVertexBuffers(slot, new SharpDX.Direct3D11.VertexBufferBinding());
+                        Context._d3dContext.InputAssembler.SetVertexBuffers(slot, new SharpDX.Direct3D11.VertexBufferBinding());
 
                     _vertexBufferSlotsUsed = 0;
                 }
@@ -1227,7 +1227,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
             if (_vertexShaderDirty)
             {
-                Context.VertexShader.Set(_vertexShader.VertexShader);
+                Context._d3dContext.VertexShader.Set(_vertexShader.VertexShader);
 
                 unchecked
                 {
@@ -1236,13 +1236,13 @@ namespace Microsoft.Xna.Framework.Graphics
             }
             if (_vertexShaderDirty || _vertexBuffersDirty)
             {
-                Context.InputAssembler.InputLayout = _vertexShader.InputLayouts.GetOrCreate(_vertexBuffers);
+                Context._d3dContext.InputAssembler.InputLayout = _vertexShader.InputLayouts.GetOrCreate(_vertexBuffers);
                 _vertexShaderDirty = _vertexBuffersDirty = false;
             }
 
             if (_pixelShaderDirty)
             {
-                Context.PixelShader.Set(_pixelShader.PixelShader);
+                Context._d3dContext.PixelShader.Set(_pixelShader.PixelShader);
                 _pixelShaderDirty = false;
 
                 unchecked
@@ -1354,10 +1354,10 @@ namespace Microsoft.Xna.Framework.Graphics
             {
                 ApplyState(true);
 
-                Context.InputAssembler.PrimitiveTopology = ToPrimitiveTopology(primitiveType);
+                Context._d3dContext.InputAssembler.PrimitiveTopology = ToPrimitiveTopology(primitiveType);
 
                 var indexCount = GetElementCountArray(primitiveType, primitiveCount);
-                Context.DrawIndexed(indexCount, startIndex, baseVertex);
+                Context._d3dContext.DrawIndexed(indexCount, startIndex, baseVertex);
             }
         }
 
@@ -1369,8 +1369,8 @@ namespace Microsoft.Xna.Framework.Graphics
             {
                 ApplyState(true);
 
-                Context.InputAssembler.PrimitiveTopology = ToPrimitiveTopology(primitiveType);
-                Context.Draw(vertexCount, startVertex);
+                Context._d3dContext.InputAssembler.PrimitiveTopology = ToPrimitiveTopology(primitiveType);
+                Context._d3dContext.Draw(vertexCount, startVertex);
             }
         }
 
@@ -1380,8 +1380,8 @@ namespace Microsoft.Xna.Framework.Graphics
             {
                 ApplyState(true);
 
-                Context.InputAssembler.PrimitiveTopology = ToPrimitiveTopology(primitiveType);
-                Context.Draw(vertexCount, vertexStart);
+                Context._d3dContext.InputAssembler.PrimitiveTopology = ToPrimitiveTopology(primitiveType);
+                Context._d3dContext.Draw(vertexCount, vertexStart);
             }
         }
 
@@ -1395,8 +1395,8 @@ namespace Microsoft.Xna.Framework.Graphics
             {
                 ApplyState(true);
 
-                Context.InputAssembler.PrimitiveTopology = ToPrimitiveTopology(primitiveType);
-                Context.DrawIndexed(indexCount, startIndex, startVertex);
+                Context._d3dContext.InputAssembler.PrimitiveTopology = ToPrimitiveTopology(primitiveType);
+                Context._d3dContext.DrawIndexed(indexCount, startIndex, startVertex);
             }
         }
 
@@ -1410,8 +1410,8 @@ namespace Microsoft.Xna.Framework.Graphics
             {
                 ApplyState(true);
 
-                Context.InputAssembler.PrimitiveTopology = ToPrimitiveTopology(primitiveType);
-                Context.DrawIndexed(indexCount, startIndex, startVertex);
+                Context._d3dContext.InputAssembler.PrimitiveTopology = ToPrimitiveTopology(primitiveType);
+                Context._d3dContext.DrawIndexed(indexCount, startIndex, startVertex);
             }
         }
 
@@ -1421,9 +1421,9 @@ namespace Microsoft.Xna.Framework.Graphics
             {
                 ApplyState(true);
 
-                Context.InputAssembler.PrimitiveTopology = ToPrimitiveTopology(primitiveType);
+                Context._d3dContext.InputAssembler.PrimitiveTopology = ToPrimitiveTopology(primitiveType);
                 int indexCount = GetElementCountArray(primitiveType, primitiveCount);
-                Context.DrawIndexedInstanced(indexCount, instanceCount, startIndex, baseVertex, 0);
+                Context._d3dContext.DrawIndexedInstanced(indexCount, instanceCount, startIndex, baseVertex, 0);
             }
         }
 
@@ -1432,7 +1432,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// </summary>
         public void Flush()
         {
-            Context.Flush();
+            Context._d3dContext.Flush();
         }
 
         private static GraphicsProfile PlatformGetHighestSupportedGraphicsProfile(GraphicsDevice graphicsDevice)

--- a/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
@@ -33,7 +33,7 @@ namespace Microsoft.Xna.Framework.Graphics
     {
         // Core Direct3D Objects
         internal SharpDX.Direct3D11.Device _d3dDevice;
-        internal SharpDX.Direct3D11.DeviceContext _d3dContext;
+        private SharpDX.Direct3D11.DeviceContext _d3dContext;
         internal SharpDX.Direct3D11.RenderTargetView _renderTargetView;
         internal SharpDX.Direct3D11.DepthStencilView _depthStencilView;
         private int _vertexBufferSlotsUsed;
@@ -96,6 +96,8 @@ namespace Microsoft.Xna.Framework.Graphics
         }
 
 #endif
+
+        internal SharpDX.Direct3D11.DeviceContext Context { get { return _graphicsContext._d3dContext; } }
 
         /// <summary>
         /// Returns a handle to internal device object. Valid only on DirectX platforms.
@@ -318,8 +320,8 @@ namespace Microsoft.Xna.Framework.Graphics
 
         internal void CreateSizeDependentResources()
         {
-            _d3dContext.OutputMerger.SetTargets((SharpDX.Direct3D11.DepthStencilView)null, 
-                                                (SharpDX.Direct3D11.RenderTargetView)null);  
+            Context.OutputMerger.SetTargets((SharpDX.Direct3D11.DepthStencilView)null, 
+                                                   (SharpDX.Direct3D11.RenderTargetView)null);  
 
             _d2dContext.Target = null;
             if (_renderTargetView != null)
@@ -345,7 +347,7 @@ namespace Microsoft.Xna.Framework.Graphics
             _currentRenderTargetCount = 0;
 
 			// Make sure all pending rendering commands are flushed.
-            _d3dContext.Flush();
+            Context.Flush();
 
             // We need presentation parameters to continue here.
             if (    PresentationParameters == null ||
@@ -666,8 +668,8 @@ namespace Microsoft.Xna.Framework.Graphics
 
         internal void CreateSizeDependentResources()
         {
-            _d3dContext.OutputMerger.SetTargets((SharpDX.Direct3D11.DepthStencilView)null,
-                                                (SharpDX.Direct3D11.RenderTargetView)null);
+            Context.OutputMerger.SetTargets((SharpDX.Direct3D11.DepthStencilView)null,
+                                                   (SharpDX.Direct3D11.RenderTargetView)null);
 
             if (_renderTargetView != null)
             {
@@ -687,7 +689,7 @@ namespace Microsoft.Xna.Framework.Graphics
             _currentRenderTargetCount = 0;
 
             // Make sure all pending rendering commands are flushed.
-            _d3dContext.Flush();
+            Context.Flush();
 
             // We need presentation parameters to continue here.
             if (PresentationParameters == null || PresentationParameters.DeviceWindowHandle == IntPtr.Zero)
@@ -835,7 +837,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 options &= ~ClearOptions.Stencil;
             }
 
-            lock (_d3dContext)
+            lock (Context)
             {
                 // Clear the diffuse render buffer.
                 if ((options & ClearOptions.Target) == ClearOptions.Target)
@@ -844,9 +846,9 @@ namespace Microsoft.Xna.Framework.Graphics
                     {
                         if (view != null)
 #if WINDOWS_UAP
-							_d3dContext.ClearRenderTargetView(view, new RawColor4(color.X, color.Y, color.Z, color.W));
+							Context.ClearRenderTargetView(view, new RawColor4(color.X, color.Y, color.Z, color.W));
 #else
-                            _d3dContext.ClearRenderTargetView(view, new Color4(color.X, color.Y, color.Z, color.W));
+                            Context.ClearRenderTargetView(view, new Color4(color.X, color.Y, color.Z, color.W));
 #endif
                     }
                 }
@@ -859,7 +861,7 @@ namespace Microsoft.Xna.Framework.Graphics
                     flags |= SharpDX.Direct3D11.DepthStencilClearFlags.Stencil;
 
                 if (flags != 0)
-                    _d3dContext.ClearDepthStencilView(_currentDepthStencilView, flags, depth, (byte)stencil);
+                    Context.ClearDepthStencilView(_currentDepthStencilView, flags, depth, (byte)stencil);
             }
         }
 
@@ -934,7 +936,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 // The first argument instructs DXGI to block until VSync, putting the application
                 // to sleep until the next VSync. This ensures we don't waste any cycles rendering
                 // frames that will never be displayed to the screen.
-                lock (_d3dContext)
+                lock (Context)
                     _swapChain.Present(1, PresentFlags.None, parameters);
             }
             catch (SharpDX.SharpDXException)
@@ -959,7 +961,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 var syncInterval = PresentationParameters.PresentationInterval.GetSyncInterval();
 
                 // The first argument instructs DXGI to block n VSyncs before presenting.
-                lock (_d3dContext)
+                lock (Context)
                     _swapChain.Present(syncInterval, PresentFlags.None);
             }
             catch (SharpDX.SharpDXException)
@@ -971,7 +973,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
         private void PlatformSetViewport(ref Viewport value)
         {
-            if (_d3dContext != null)
+            if (Context != null)
             {
 #if WINDOWS_UAP
 				var viewport = new RawViewportF
@@ -986,8 +988,8 @@ namespace Microsoft.Xna.Framework.Graphics
 #else
                 var viewport = new SharpDX.ViewportF(_viewport.X, _viewport.Y, (float)_viewport.Width, (float)_viewport.Height, _viewport.MinDepth, _viewport.MaxDepth);
 #endif
-                lock (_d3dContext)
-                    _d3dContext.Rasterizer.SetViewport(viewport);
+                lock (Context)
+                    Context.Rasterizer.SetViewport(viewport);
             }
         }
 
@@ -1019,8 +1021,8 @@ namespace Microsoft.Xna.Framework.Graphics
             _currentRenderTargets[0] = _renderTargetView;
             _currentDepthStencilView = _depthStencilView;
 
-            lock (_d3dContext)
-                _d3dContext.OutputMerger.SetTargets(_currentDepthStencilView, _currentRenderTargets);
+            lock (Context)
+                Context.OutputMerger.SetTargets(_currentDepthStencilView, _currentRenderTargets);
         }
 
         internal void PlatformResolveRenderTargets()
@@ -1033,8 +1035,8 @@ namespace Microsoft.Xna.Framework.Graphics
                 var renderTargetBinding = _currentRenderTargetBindings[i];
                 if (renderTargetBinding.RenderTarget.LevelCount > 1)
                 {
-                    lock (_d3dContext)
-                        _d3dContext.GenerateMips(renderTargetBinding.RenderTarget.GetShaderResourceView());
+                    lock (Context)
+                        Context.GenerateMips(renderTargetBinding.RenderTarget.GetShaderResourceView());
                 }
             }
         }
@@ -1047,7 +1049,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
             // Make sure none of the new targets are bound
             // to the device as a texture resource.
-            lock (_d3dContext)
+            lock (Context)
             {
                 VertexTextures.ClearTargets(this, _currentRenderTargetBindings);
                 Textures.ClearTargets(this, _currentRenderTargetBindings);
@@ -1065,8 +1067,8 @@ namespace Microsoft.Xna.Framework.Graphics
             _currentDepthStencilView = renderTarget.GetDepthStencilView();
 
             // Set the targets.
-            lock (_d3dContext)
-                _d3dContext.OutputMerger.SetTargets(_currentDepthStencilView, _currentRenderTargets);
+            lock (Context)
+                Context.OutputMerger.SetTargets(_currentDepthStencilView, _currentRenderTargets);
 
             return renderTarget;
         }
@@ -1074,9 +1076,9 @@ namespace Microsoft.Xna.Framework.Graphics
 #if WINRT
         internal void ResetRenderTargets()
         {
-            if (_d3dContext != null)
+            if (Context != null)
             {
-                lock (_d3dContext)
+                lock (Context)
                 {
 #if WINDOWS_UAP
 					var viewport = new RawViewportF
@@ -1093,8 +1095,8 @@ namespace Microsoft.Xna.Framework.Graphics
                                                           _viewport.Width, _viewport.Height, 
                                                           _viewport.MinDepth, _viewport.MaxDepth);
 #endif
-                    _d3dContext.Rasterizer.SetViewport(viewport);
-                    _d3dContext.OutputMerger.SetTargets(_currentDepthStencilView, _currentRenderTargets);
+                    Context.Rasterizer.SetViewport(viewport);
+                    Context.OutputMerger.SetTargets(_currentDepthStencilView, _currentRenderTargets);
                 }
             }
 
@@ -1130,7 +1132,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
         internal void PlatformBeginApplyState()
         {
-            Debug.Assert(_d3dContext != null, "The d3d context is null!");
+            Debug.Assert(Context != null, "The d3d context is null!");
         }
 
         private void PlatformApplyBlend()
@@ -1139,7 +1141,7 @@ namespace Microsoft.Xna.Framework.Graphics
             {
                 var state = _actualBlendState.GetDxState(this);
                 var factor = GetBlendFactor();
-                _d3dContext.OutputMerger.SetBlendState(state, factor);
+                Context.OutputMerger.SetBlendState(state, factor);
 
                 _blendFactorDirty = false;
                 _blendStateDirty = false;
@@ -1164,11 +1166,11 @@ namespace Microsoft.Xna.Framework.Graphics
 
         internal void PlatformApplyState(bool applyShaders)
         {
-            // NOTE: This code assumes _d3dContext has been locked by the caller.
+            // NOTE: This code assumes Context has been locked by the caller.
 
             if (_scissorRectangleDirty)
             {
-                _d3dContext.Rasterizer.SetScissorRectangle(
+                Context.Rasterizer.SetScissorRectangle(
                     _scissorRectangle.X,
                     _scissorRectangle.Y,
                     _scissorRectangle.Right,
@@ -1184,7 +1186,7 @@ namespace Microsoft.Xna.Framework.Graphics
             {
                 if (_indexBuffer != null)
                 {
-                    _d3dContext.InputAssembler.SetIndexBuffer(
+                    Context.InputAssembler.SetIndexBuffer(
                         _indexBuffer.Buffer,
                         _indexBuffer.IndexElementSize == IndexElementSize.SixteenBits ?
                             SharpDX.DXGI.Format.R16_UInt : SharpDX.DXGI.Format.R32_UInt,
@@ -1204,7 +1206,7 @@ namespace Microsoft.Xna.Framework.Graphics
                         var vertexDeclaration = vertexBuffer.VertexDeclaration;
                         int vertexStride = vertexDeclaration.VertexStride;
                         int vertexOffsetInBytes = vertexBufferBinding.VertexOffset * vertexStride;
-                        _d3dContext.InputAssembler.SetVertexBuffers(
+                        Context.InputAssembler.SetVertexBuffers(
                             slot, new SharpDX.Direct3D11.VertexBufferBinding(vertexBuffer.Buffer, vertexStride, vertexOffsetInBytes));
                     }
                     _vertexBufferSlotsUsed = _vertexBuffers.Count;
@@ -1212,7 +1214,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 else
                 {
                     for (int slot = 0; slot < _vertexBufferSlotsUsed; slot++)
-                        _d3dContext.InputAssembler.SetVertexBuffers(slot, new SharpDX.Direct3D11.VertexBufferBinding());
+                        Context.InputAssembler.SetVertexBuffers(slot, new SharpDX.Direct3D11.VertexBufferBinding());
 
                     _vertexBufferSlotsUsed = 0;
                 }
@@ -1225,7 +1227,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
             if (_vertexShaderDirty)
             {
-                _d3dContext.VertexShader.Set(_vertexShader.VertexShader);
+                Context.VertexShader.Set(_vertexShader.VertexShader);
 
                 unchecked
                 {
@@ -1234,13 +1236,13 @@ namespace Microsoft.Xna.Framework.Graphics
             }
             if (_vertexShaderDirty || _vertexBuffersDirty)
             {
-                _d3dContext.InputAssembler.InputLayout = _vertexShader.InputLayouts.GetOrCreate(_vertexBuffers);
+                Context.InputAssembler.InputLayout = _vertexShader.InputLayouts.GetOrCreate(_vertexBuffers);
                 _vertexShaderDirty = _vertexBuffersDirty = false;
             }
 
             if (_pixelShaderDirty)
             {
-                _d3dContext.PixelShader.Set(_pixelShader.PixelShader);
+                Context.PixelShader.Set(_pixelShader.PixelShader);
                 _pixelShaderDirty = false;
 
                 unchecked
@@ -1348,14 +1350,14 @@ namespace Microsoft.Xna.Framework.Graphics
 
         private void PlatformDrawIndexedPrimitives(PrimitiveType primitiveType, int baseVertex, int startIndex, int primitiveCount)
         {
-            lock (_d3dContext)
+            lock (Context)
             {
                 ApplyState(true);
 
-                _d3dContext.InputAssembler.PrimitiveTopology = ToPrimitiveTopology(primitiveType);
+                Context.InputAssembler.PrimitiveTopology = ToPrimitiveTopology(primitiveType);
 
                 var indexCount = GetElementCountArray(primitiveType, primitiveCount);
-                _d3dContext.DrawIndexed(indexCount, startIndex, baseVertex);
+                Context.DrawIndexed(indexCount, startIndex, baseVertex);
             }
         }
 
@@ -1363,23 +1365,23 @@ namespace Microsoft.Xna.Framework.Graphics
         {
             var startVertex = SetUserVertexBuffer(vertexData, vertexOffset, vertexCount, vertexDeclaration);
 
-            lock (_d3dContext)
+            lock (Context)
             {
                 ApplyState(true);
 
-                _d3dContext.InputAssembler.PrimitiveTopology = ToPrimitiveTopology(primitiveType);
-                _d3dContext.Draw(vertexCount, startVertex);
+                Context.InputAssembler.PrimitiveTopology = ToPrimitiveTopology(primitiveType);
+                Context.Draw(vertexCount, startVertex);
             }
         }
 
         private void PlatformDrawPrimitives(PrimitiveType primitiveType, int vertexStart, int vertexCount)
         {
-            lock (_d3dContext)
+            lock (Context)
             {
                 ApplyState(true);
 
-                _d3dContext.InputAssembler.PrimitiveTopology = ToPrimitiveTopology(primitiveType);
-                _d3dContext.Draw(vertexCount, vertexStart);
+                Context.InputAssembler.PrimitiveTopology = ToPrimitiveTopology(primitiveType);
+                Context.Draw(vertexCount, vertexStart);
             }
         }
 
@@ -1389,12 +1391,12 @@ namespace Microsoft.Xna.Framework.Graphics
             var startVertex = SetUserVertexBuffer(vertexData, vertexOffset, numVertices, vertexDeclaration);
             var startIndex = SetUserIndexBuffer(indexData, indexOffset, indexCount);
 
-            lock (_d3dContext)
+            lock (Context)
             {
                 ApplyState(true);
 
-                _d3dContext.InputAssembler.PrimitiveTopology = ToPrimitiveTopology(primitiveType);
-                _d3dContext.DrawIndexed(indexCount, startIndex, startVertex);
+                Context.InputAssembler.PrimitiveTopology = ToPrimitiveTopology(primitiveType);
+                Context.DrawIndexed(indexCount, startIndex, startVertex);
             }
         }
 
@@ -1404,24 +1406,24 @@ namespace Microsoft.Xna.Framework.Graphics
             var startVertex = SetUserVertexBuffer(vertexData, vertexOffset, numVertices, vertexDeclaration);
             var startIndex = SetUserIndexBuffer(indexData, indexOffset, indexCount);
 
-            lock (_d3dContext)
+            lock (Context)
             {
                 ApplyState(true);
 
-                _d3dContext.InputAssembler.PrimitiveTopology = ToPrimitiveTopology(primitiveType);
-                _d3dContext.DrawIndexed(indexCount, startIndex, startVertex);
+                Context.InputAssembler.PrimitiveTopology = ToPrimitiveTopology(primitiveType);
+                Context.DrawIndexed(indexCount, startIndex, startVertex);
             }
         }
 
         private void PlatformDrawInstancedPrimitives(PrimitiveType primitiveType, int baseVertex, int startIndex, int primitiveCount, int instanceCount)
         {
-            lock (_d3dContext)
+            lock (Context)
             {
                 ApplyState(true);
 
-                _d3dContext.InputAssembler.PrimitiveTopology = ToPrimitiveTopology(primitiveType);
+                Context.InputAssembler.PrimitiveTopology = ToPrimitiveTopology(primitiveType);
                 int indexCount = GetElementCountArray(primitiveType, primitiveCount);
-                _d3dContext.DrawIndexedInstanced(indexCount, instanceCount, startIndex, baseVertex, 0);
+                Context.DrawIndexedInstanced(indexCount, instanceCount, startIndex, baseVertex, 0);
             }
         }
 
@@ -1430,7 +1432,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// </summary>
         public void Flush()
         {
-            _d3dContext.Flush();
+            Context.Flush();
         }
 
         private static GraphicsProfile PlatformGetHighestSupportedGraphicsProfile(GraphicsDevice graphicsDevice)

--- a/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
@@ -33,7 +33,6 @@ namespace Microsoft.Xna.Framework.Graphics
     {
         // Core Direct3D Objects
         internal SharpDX.Direct3D11.Device _d3dDevice;
-        private GraphicsContext _context;
         internal SharpDX.Direct3D11.RenderTargetView _renderTargetView;
         internal SharpDX.Direct3D11.DepthStencilView _depthStencilView;
         private int _vertexBufferSlotsUsed;
@@ -97,8 +96,6 @@ namespace Microsoft.Xna.Framework.Graphics
 
 #endif
         
-        internal GraphicsContext Context { get { return _context; } }
-
         /// <summary>
         /// Returns a handle to internal device object. Valid only on DirectX platforms.
         /// For usage, convert this to SharpDX.Direct3D11.Device.

--- a/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
@@ -1132,35 +1132,6 @@ namespace Microsoft.Xna.Framework.Graphics
             Debug.Assert(Context != null, "The d3d context is null!");
         }
 
-        private void PlatformApplyBlend()
-        {
-            if (_blendFactorDirty || _blendStateDirty)
-            {
-                var state = _actualBlendState.GetDxState(this);
-                var factor = GetBlendFactor();
-                Context._d3dContext.OutputMerger.SetBlendState(state, factor);
-
-                _blendFactorDirty = false;
-                _blendStateDirty = false;
-            }
-        }
-
-#if WINDOWS_UAP
-        private SharpDX.Mathematics.Interop.RawColor4 GetBlendFactor()
-        {
-			return new SharpDX.Mathematics.Interop.RawColor4(
-					BlendFactor.R / 255.0f,
-					BlendFactor.G / 255.0f,
-					BlendFactor.B / 255.0f,
-					BlendFactor.A / 255.0f);
-        }
-#else
-        private Color4 GetBlendFactor()
-        {
-			return BlendFactor.ToColor4();
-        }
-#endif
-
         internal void PlatformApplyState(bool applyShaders)
         {
             // NOTE: This code assumes Context has been locked by the caller.

--- a/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.DirectX.cs
@@ -821,7 +821,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
 #endif // WINDOWS
 
-        public void PlatformClear(ClearOptions options, Vector4 color, float depth, int stencil)
+        private void PlatformClear(ClearOptions options, Vector4 color, float depth, int stencil)
         {
             // Clear options for depth/stencil buffer if not attached.
             if (_currentDepthStencilView != null)
@@ -920,7 +920,7 @@ namespace Microsoft.Xna.Framework.Graphics
 #endif // WINDOWS_STOREAPP
         }
         
-        public void PlatformPresent()
+        private void PlatformPresent()
         {
 #if WINDOWS_STOREAPP || WINDOWS_UAP
             // The application may optionally specify "dirty" or "scroll" rects to improve efficiency

--- a/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
@@ -63,7 +63,6 @@ namespace Microsoft.Xna.Framework.Graphics
 
         // Keeps track of last applied state to avoid redundant OpenGL calls
         internal bool _lastBlendEnable = false;
-        internal BlendState _lastBlendState = new BlendState();
         internal DepthStencilState _lastDepthStencilState = new DepthStencilState();
         internal RasterizerState _lastRasterizerState = new RasterizerState();
         private Vector4 _lastClearColor = Vector4.Zero;
@@ -293,7 +292,7 @@ namespace Microsoft.Xna.Framework.Graphics
             }
 
             // Force resetting states
-            this.PlatformApplyBlend(true);
+            Context.ApplyBlend(true);
             this.DepthStencilState.PlatformApplyState(this, true);
             this.RasterizerState.PlatformApplyState(this, true);            
 
@@ -832,26 +831,6 @@ namespace Microsoft.Xna.Framework.Graphics
         internal void PlatformBeginApplyState()
         {
             Threading.EnsureUIThread();
-        }
-
-        private void PlatformApplyBlend(bool force = false)
-        {
-            _actualBlendState.PlatformApplyState(this, force);
-            ApplyBlendFactor(force);
-        }
-
-        private void ApplyBlendFactor(bool force)
-        {
-            if (force || BlendFactor != _lastBlendState.BlendFactor)
-            {
-                GL.BlendColor(
-                    this.BlendFactor.R/255.0f,
-                    this.BlendFactor.G/255.0f,
-                    this.BlendFactor.B/255.0f,
-                    this.BlendFactor.A/255.0f);
-                GraphicsExtensions.CheckGLError();
-                _lastBlendState.BlendFactor = this.BlendFactor;
-            }
         }
 
         internal void PlatformApplyState(bool applyShaders)

--- a/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
@@ -37,9 +37,8 @@ namespace Microsoft.Xna.Framework.Graphics
 {
     public partial class GraphicsDevice
     {
-#if DESKTOPGL || ANGLE
-        internal IGraphicsContext Context { get; private set; }
-#endif
+        private GraphicsContext _context;
+        internal GraphicsContext Context { get { return _context; } }
 
 #if !GLES
         private DrawBuffersEnum[] _drawBuffers;
@@ -99,9 +98,9 @@ namespace Microsoft.Xna.Framework.Graphics
 
             var windowInfo = new WindowInfo(SdlGameWindow.Instance.Handle);
 
-            if (Context == null || Context.IsDisposed)
+            if (_context == null || _context.IsDisposed)
             {
-                Context = GL.CreateContext(windowInfo);
+                _context = new GraphicsContext(this, windowInfo);
             }
 
             Context.MakeCurrent(windowInfo);
@@ -384,10 +383,8 @@ namespace Microsoft.Xna.Framework.Graphics
 
             GraphicsDevice.AddDisposeAction(() =>
                                             {
-#if DESKTOPGL || ANGLE
-                Context.Dispose();
-                Context = null;
-#endif
+                _context.Dispose();
+                _context = null;
             });
         }
 

--- a/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.OpenGL.cs
@@ -37,9 +37,6 @@ namespace Microsoft.Xna.Framework.Graphics
 {
     public partial class GraphicsDevice
     {
-        private GraphicsContext _context;
-        internal GraphicsContext Context { get { return _context; } }
-
 #if !GLES
         private DrawBuffersEnum[] _drawBuffers;
 #endif

--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -18,18 +18,6 @@ namespace Microsoft.Xna.Framework.Graphics
 
         private GraphicsContext _context;
 
-        private Color _blendFactor = Color.White;
-        private bool _blendFactorDirty;
-
-        private BlendState _blendState;
-        private BlendState _actualBlendState;
-        private bool _blendStateDirty;
-
-        private BlendState _blendStateAdditive;
-        private BlendState _blendStateAlphaBlend;
-        private BlendState _blendStateNonPremultiplied;
-        private BlendState _blendStateOpaque;
-
         private DepthStencilState _depthStencilState;
         private DepthStencilState _actualDepthStencilState;
         private bool _depthStencilStateDirty;
@@ -248,13 +236,6 @@ namespace Microsoft.Xna.Framework.Graphics
             Textures = new TextureCollection(this, MaxTextureSlots, false);
             SamplerStates = new SamplerStateCollection(this, MaxTextureSlots, false);
 
-            _blendStateAdditive = BlendState.Additive.Clone();
-            _blendStateAlphaBlend = BlendState.AlphaBlend.Clone();
-            _blendStateNonPremultiplied = BlendState.NonPremultiplied.Clone();
-            _blendStateOpaque = BlendState.Opaque.Clone();
-
-            BlendState = BlendState.Opaque;
-
             _depthStencilStateDefault = DepthStencilState.Default.Clone();
             _depthStencilStateDepthRead = DepthStencilState.DepthRead.Clone();
             _depthStencilStateNone = DepthStencilState.None.Clone();
@@ -281,8 +262,8 @@ namespace Microsoft.Xna.Framework.Graphics
             GraphicsCapabilities.InitializeAfterResources(this);
 
             // Force set the default render states.
-            _blendStateDirty = _depthStencilStateDirty = _rasterizerStateDirty = true;
-            BlendState = BlendState.Opaque;
+            Context.SetDefaultRenderStates();
+            _depthStencilStateDirty = _rasterizerStateDirty = true;
             DepthStencilState = DepthStencilState.Default;
             RasterizerState = RasterizerState.CullCounterClockwise;
 
@@ -360,52 +341,14 @@ namespace Microsoft.Xna.Framework.Graphics
         /// </remarks>
         public Color BlendFactor
         {
-            get { return _blendFactor; }
-            set
-            {
-                if (_blendFactor == value)
-                    return;
-                _blendFactor = value;
-                _blendFactorDirty = true;
-            }
+            get { return Context.BlendFactor; }
+            set { Context.BlendFactor = value; }
         }
 
         public BlendState BlendState
         {
-			get { return _blendState; }
-			set
-            {
-                if (value == null)
-                    throw new ArgumentNullException("value");
-
-                // Don't set the same state twice!
-                if (_blendState == value)
-                    return;
-
-				_blendState = value;
-
-                // Static state properties never actually get bound;
-                // instead we use our GraphicsDevice-specific version of them.
-                var newBlendState = _blendState;
-                if (ReferenceEquals(_blendState, BlendState.Additive))
-                    newBlendState = _blendStateAdditive;
-                else if (ReferenceEquals(_blendState, BlendState.AlphaBlend))
-                    newBlendState = _blendStateAlphaBlend;
-                else if (ReferenceEquals(_blendState, BlendState.NonPremultiplied))
-                    newBlendState = _blendStateNonPremultiplied;
-                else if (ReferenceEquals(_blendState, BlendState.Opaque))
-                    newBlendState = _blendStateOpaque;
-
-                // Blend state is now bound to a device... no one should
-                // be changing the state of the blend state object now!
-                newBlendState.BindToGraphicsDevice(this);
-
-                _actualBlendState = newBlendState;
-
-                BlendFactor = _actualBlendState.BlendFactor;
-
-                _blendStateDirty = true;
-            }
+			get { return Context.BlendState; }
+			set { Context.BlendState = value; }
 		}
 
         public DepthStencilState DepthStencilState
@@ -444,7 +387,7 @@ namespace Microsoft.Xna.Framework.Graphics
         {
             PlatformBeginApplyState();
 
-            PlatformApplyBlend();
+            Context.ApplyBlend();
 
             if (_depthStencilStateDirty)
             {

--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -16,6 +16,8 @@ namespace Microsoft.Xna.Framework.Graphics
 
         private bool _isDisposed;
 
+        private GraphicsContext _context;
+
         private Color _blendFactor = Color.White;
         private bool _blendFactorDirty;
 
@@ -56,6 +58,8 @@ namespace Microsoft.Xna.Framework.Graphics
         private readonly RenderTargetBinding[] _currentRenderTargetBindings = new RenderTargetBinding[4];
         private int _currentRenderTargetCount;
         private readonly RenderTargetBinding[] _tempRenderTargetBinding = new RenderTargetBinding[1];
+
+        internal GraphicsContext Context { get { return _context; } }
 
         internal GraphicsCapabilities GraphicsCapabilities { get; private set; }
 

--- a/MonoGame.Framework/Graphics/GraphicsDevice.cs
+++ b/MonoGame.Framework/Graphics/GraphicsDevice.cs
@@ -571,9 +571,6 @@ namespace Microsoft.Xna.Framework.Graphics
 
             if (DeviceReset != null)
                 DeviceReset(this, EventArgs.Empty);
-
-            if (DeviceLost != null)
-                DeviceLost(this, EventArgs.Empty);
         }
 
         public void Reset(PresentationParameters presentationParameters)

--- a/MonoGame.Framework/Graphics/OcclusionQuery.DirectX.cs
+++ b/MonoGame.Framework/Graphics/OcclusionQuery.DirectX.cs
@@ -25,21 +25,21 @@ namespace Microsoft.Xna.Framework.Graphics
         
         private void PlatformBegin()
         {
-            var d3dContext = GraphicsDevice._d3dContext;
+            var d3dContext = GraphicsDevice.Context;
             lock(d3dContext)
                 d3dContext.Begin(_query);
         }
 
         private void PlatformEnd()
         {
-            var d3dContext = GraphicsDevice._d3dContext;
+            var d3dContext = GraphicsDevice.Context;
             lock (d3dContext)
                 d3dContext.End(_query);
         }
 
         private bool PlatformGetResult(out int pixelCount)
         {
-            var d3dContext = GraphicsDevice._d3dContext;
+            var d3dContext = GraphicsDevice.Context;
             ulong count;
             bool isComplete;
 

--- a/MonoGame.Framework/Graphics/OcclusionQuery.DirectX.cs
+++ b/MonoGame.Framework/Graphics/OcclusionQuery.DirectX.cs
@@ -25,26 +25,26 @@ namespace Microsoft.Xna.Framework.Graphics
         
         private void PlatformBegin()
         {
-            var d3dContext = GraphicsDevice.Context;
-            lock(d3dContext)
-                d3dContext.Begin(_query);
+            var context = GraphicsDevice.Context;
+            lock(context)
+                context._d3dContext.Begin(_query);
         }
 
         private void PlatformEnd()
         {
-            var d3dContext = GraphicsDevice.Context;
-            lock (d3dContext)
-                d3dContext.End(_query);
+            var context = GraphicsDevice.Context;
+            lock (context)
+                context._d3dContext.End(_query);
         }
 
         private bool PlatformGetResult(out int pixelCount)
         {
-            var d3dContext = GraphicsDevice.Context;
+            var context = GraphicsDevice.Context;
             ulong count;
             bool isComplete;
 
-            lock (d3dContext)
-                isComplete = d3dContext.GetData(_query, out count);
+            lock (context)
+                isComplete = context._d3dContext.GetData(_query, out count);
 
             pixelCount = (int)count;
             return isComplete;

--- a/MonoGame.Framework/Graphics/OpenGL.SDL.cs
+++ b/MonoGame.Framework/Graphics/OpenGL.SDL.cs
@@ -14,11 +14,6 @@ namespace OpenGL
         {
             BoundApi = RenderApi.GL;
         }
-
-        private static IGraphicsContext PlatformCreateContext (IWindowInfo info)
-        {
-            return new GraphicsContext(info);
-        }
     }
 
     internal class EntryPointHelper {

--- a/MonoGame.Framework/Graphics/OpenGL.cs
+++ b/MonoGame.Framework/Graphics/OpenGL.cs
@@ -1209,11 +1209,6 @@ namespace OpenGL
 
         static partial void LoadPlatformEntryPoints();
 
-        public static IGraphicsContext CreateContext(IWindowInfo info)
-        {
-            return PlatformCreateContext(info);
-        }
-
         /* Helper Functions */
 
         public static void Uniform1 (int location, int value) {

--- a/MonoGame.Framework/Graphics/SamplerStateCollection.DirectX.cs
+++ b/MonoGame.Framework/Graphics/SamplerStateCollection.DirectX.cs
@@ -38,9 +38,9 @@ namespace Microsoft.Xna.Framework.Graphics
             // locked the d3dContext for us to use.
             SharpDX.Direct3D11.CommonShaderStage shaderStage;
             if (_applyToVertexStage)
-	            shaderStage = device._d3dContext.VertexShader;
+	            shaderStage = device.Context.VertexShader;
             else
-	            shaderStage = device._d3dContext.PixelShader;
+	            shaderStage = device.Context.PixelShader;
 
             for (var i = 0; i < _actualSamplers.Length; i++)
             {

--- a/MonoGame.Framework/Graphics/SamplerStateCollection.DirectX.cs
+++ b/MonoGame.Framework/Graphics/SamplerStateCollection.DirectX.cs
@@ -35,12 +35,12 @@ namespace Microsoft.Xna.Framework.Graphics
                 return;
 
             // NOTE: We make the assumption here that the caller has
-            // locked the d3dContext for us to use.
+            // locked the GraphicsContext for us to use.
             SharpDX.Direct3D11.CommonShaderStage shaderStage;
             if (_applyToVertexStage)
-	            shaderStage = device.Context.VertexShader;
+	            shaderStage = device.Context._d3dContext.VertexShader;
             else
-	            shaderStage = device.Context.PixelShader;
+	            shaderStage = device.Context._d3dContext.PixelShader;
 
             for (var i = 0; i < _actualSamplers.Length; i++)
             {

--- a/MonoGame.Framework/Graphics/Shader/ConstantBuffer.DirectX.cs
+++ b/MonoGame.Framework/Graphics/Shader/ConstantBuffer.DirectX.cs
@@ -17,7 +17,7 @@ namespace Microsoft.Xna.Framework.Graphics
             desc.Usage = SharpDX.Direct3D11.ResourceUsage.Default;
             desc.BindFlags = SharpDX.Direct3D11.BindFlags.ConstantBuffer;
             desc.CpuAccessFlags = SharpDX.Direct3D11.CpuAccessFlags.None;
-            lock (GraphicsDevice._d3dContext)
+            lock (GraphicsDevice.Context)
                 _cbuffer = new SharpDX.Direct3D11.Buffer(GraphicsDevice._d3dDevice, desc);
         }
 
@@ -34,7 +34,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
             // NOTE: We make the assumption here that the caller has
             // locked the d3dContext for us to use.
-            var d3dContext = GraphicsDevice._d3dContext;
+            var d3dContext = GraphicsDevice.Context;
 
             // Update the hardware buffer.
             if (_dirty)

--- a/MonoGame.Framework/Graphics/Shader/ConstantBuffer.DirectX.cs
+++ b/MonoGame.Framework/Graphics/Shader/ConstantBuffer.DirectX.cs
@@ -33,21 +33,21 @@ namespace Microsoft.Xna.Framework.Graphics
                 PlatformInitialize();
 
             // NOTE: We make the assumption here that the caller has
-            // locked the d3dContext for us to use.
-            var d3dContext = GraphicsDevice.Context;
+            // locked the GraphicsContext for us to use.
+            var context = GraphicsDevice.Context;
 
             // Update the hardware buffer.
             if (_dirty)
             {
-                d3dContext.UpdateSubresource(_buffer, _cbuffer);
+                context._d3dContext.UpdateSubresource(_buffer, _cbuffer);
                 _dirty = false;
             }
             
             // Set the buffer to the right stage.
             if (stage == ShaderStage.Vertex)
-                d3dContext.VertexShader.SetConstantBuffer(slot, _cbuffer);
+                context._d3dContext.VertexShader.SetConstantBuffer(slot, _cbuffer);
             else
-                d3dContext.PixelShader.SetConstantBuffer(slot, _cbuffer);
+                context._d3dContext.PixelShader.SetConstantBuffer(slot, _cbuffer);
         }
 
         protected override void Dispose(bool disposing)

--- a/MonoGame.Framework/Graphics/States/BlendState.OpenGL.cs
+++ b/MonoGame.Framework/Graphics/States/BlendState.OpenGL.cs
@@ -35,22 +35,22 @@ namespace Microsoft.Xna.Framework.Graphics
             }
 
             if (force || 
-                this.ColorBlendFunction != device._lastBlendState.ColorBlendFunction || 
-                this.AlphaBlendFunction != device._lastBlendState.AlphaBlendFunction)
+                this.ColorBlendFunction != device.Context._lastBlendState.ColorBlendFunction || 
+                this.AlphaBlendFunction != device.Context._lastBlendState.AlphaBlendFunction)
             {
                 GL.BlendEquationSeparate(
                     this.ColorBlendFunction.GetBlendEquationMode(),
                     this.AlphaBlendFunction.GetBlendEquationMode());
                 GraphicsExtensions.CheckGLError();
-                device._lastBlendState.ColorBlendFunction = this.ColorBlendFunction;
-                device._lastBlendState.AlphaBlendFunction = this.AlphaBlendFunction;
+                device.Context._lastBlendState.ColorBlendFunction = this.ColorBlendFunction;
+                device.Context._lastBlendState.AlphaBlendFunction = this.AlphaBlendFunction;
             }
 
             if (force ||
-                this.ColorSourceBlend != device._lastBlendState.ColorSourceBlend ||
-                this.ColorDestinationBlend != device._lastBlendState.ColorDestinationBlend ||
-                this.AlphaSourceBlend != device._lastBlendState.AlphaSourceBlend ||
-                this.AlphaDestinationBlend != device._lastBlendState.AlphaDestinationBlend)
+                this.ColorSourceBlend != device.Context._lastBlendState.ColorSourceBlend ||
+                this.ColorDestinationBlend != device.Context._lastBlendState.ColorDestinationBlend ||
+                this.AlphaSourceBlend != device.Context._lastBlendState.AlphaSourceBlend ||
+                this.AlphaDestinationBlend != device.Context._lastBlendState.AlphaDestinationBlend)
             {
                 GL.BlendFuncSeparate(
                     this.ColorSourceBlend.GetBlendFactorSrc(), 
@@ -58,13 +58,13 @@ namespace Microsoft.Xna.Framework.Graphics
                     this.AlphaSourceBlend.GetBlendFactorSrc(), 
                     this.AlphaDestinationBlend.GetBlendFactorDest());
                 GraphicsExtensions.CheckGLError();
-                device._lastBlendState.ColorSourceBlend = this.ColorSourceBlend;
-                device._lastBlendState.ColorDestinationBlend = this.ColorDestinationBlend;
-                device._lastBlendState.AlphaSourceBlend = this.AlphaSourceBlend;
-                device._lastBlendState.AlphaDestinationBlend = this.AlphaDestinationBlend;
+                device.Context._lastBlendState.ColorSourceBlend = this.ColorSourceBlend;
+                device.Context._lastBlendState.ColorDestinationBlend = this.ColorDestinationBlend;
+                device.Context._lastBlendState.AlphaSourceBlend = this.AlphaSourceBlend;
+                device.Context._lastBlendState.AlphaDestinationBlend = this.AlphaDestinationBlend;
             }
 
-            if (force || this.ColorWriteChannels != device._lastBlendState.ColorWriteChannels)
+            if (force || this.ColorWriteChannels != device.Context._lastBlendState.ColorWriteChannels)
             {
                 GL.ColorMask(
                     (this.ColorWriteChannels & ColorWriteChannels.Red) != 0,
@@ -72,7 +72,7 @@ namespace Microsoft.Xna.Framework.Graphics
                     (this.ColorWriteChannels & ColorWriteChannels.Blue) != 0,
                     (this.ColorWriteChannels & ColorWriteChannels.Alpha) != 0);
                 GraphicsExtensions.CheckGLError();
-                device._lastBlendState.ColorWriteChannels = this.ColorWriteChannels;
+                device.Context._lastBlendState.ColorWriteChannels = this.ColorWriteChannels;
             }
 
             

--- a/MonoGame.Framework/Graphics/States/DepthStencilState.DirectX.cs
+++ b/MonoGame.Framework/Graphics/States/DepthStencilState.DirectX.cs
@@ -66,7 +66,7 @@ namespace Microsoft.Xna.Framework.Graphics
             // locked the d3dContext for us to use.
 
             // Apply the state!
-            device._d3dContext.OutputMerger.SetDepthStencilState(_state, ReferenceStencil);
+            device.Context.OutputMerger.SetDepthStencilState(_state, ReferenceStencil);
         }
 
         static private SharpDX.Direct3D11.StencilOperation GetStencilOp(StencilOperation op)

--- a/MonoGame.Framework/Graphics/States/DepthStencilState.DirectX.cs
+++ b/MonoGame.Framework/Graphics/States/DepthStencilState.DirectX.cs
@@ -63,10 +63,10 @@ namespace Microsoft.Xna.Framework.Graphics
             Debug.Assert(GraphicsDevice == device, "The state was created for a different device!");
 
             // NOTE: We make the assumption here that the caller has
-            // locked the d3dContext for us to use.
+            // locked the GraphicsContext for us to use.
 
             // Apply the state!
-            device.Context.OutputMerger.SetDepthStencilState(_state, ReferenceStencil);
+            device.Context._d3dContext.OutputMerger.SetDepthStencilState(_state, ReferenceStencil);
         }
 
         static private SharpDX.Direct3D11.StencilOperation GetStencilOp(StencilOperation op)

--- a/MonoGame.Framework/Graphics/States/RasterizerState.DirectX.cs
+++ b/MonoGame.Framework/Graphics/States/RasterizerState.DirectX.cs
@@ -86,10 +86,10 @@ namespace Microsoft.Xna.Framework.Graphics
             Debug.Assert(GraphicsDevice == device, "The state was created for a different device!");
 
             // NOTE: We make the assumption here that the caller has
-            // locked the d3dContext for us to use.
+            // locked the GraphicsContext for us to use.
 
             // Apply the state!
-            device.Context.Rasterizer.State = _state;
+            device.Context._d3dContext.Rasterizer.State = _state;
         }
 
         protected override void Dispose(bool disposing)

--- a/MonoGame.Framework/Graphics/States/RasterizerState.DirectX.cs
+++ b/MonoGame.Framework/Graphics/States/RasterizerState.DirectX.cs
@@ -89,7 +89,7 @@ namespace Microsoft.Xna.Framework.Graphics
             // locked the d3dContext for us to use.
 
             // Apply the state!
-            device._d3dContext.Rasterizer.State = _state;
+            device.Context.Rasterizer.State = _state;
         }
 
         protected override void Dispose(bool disposing)

--- a/MonoGame.Framework/Graphics/SwapChainRenderTarget.cs
+++ b/MonoGame.Framework/Graphics/SwapChainRenderTarget.cs
@@ -152,7 +152,7 @@ namespace Microsoft.Xna.Framework.Graphics
         /// </summary>
         public void Present()
         {
-            lock (GraphicsDevice._d3dContext)
+            lock (GraphicsDevice.Context)
             {
                 try
                 {

--- a/MonoGame.Framework/Graphics/Texture2D.DirectX.cs
+++ b/MonoGame.Framework/Graphics/Texture2D.DirectX.cs
@@ -65,9 +65,9 @@ namespace Microsoft.Xna.Framework.Graphics
                 
                 // TODO: We need to deal with threaded contexts here!
                 var subresourceIndex = CalculateSubresourceIndex(arraySlice, level);
-                var d3dContext = GraphicsDevice.Context;
-                lock (d3dContext)
-                    d3dContext.UpdateSubresource(GetTexture(), subresourceIndex, region, dataPtr, GetPitch(rect.Width), 0);
+                var context = GraphicsDevice.Context;
+                lock (context)
+                    context._d3dContext.UpdateSubresource(GetTexture(), subresourceIndex, region, dataPtr, GetPitch(rect.Width), 0);
             }
             finally
             {
@@ -102,10 +102,10 @@ namespace Microsoft.Xna.Framework.Graphics
             // Save sampling description.
             _sampleDescription = desc.SampleDescription;
 
-            var d3dContext = GraphicsDevice.Context;
+            var context = GraphicsDevice.Context;
             using (var stagingTex = new SharpDX.Direct3D11.Texture2D(GraphicsDevice._d3dDevice, desc))
             {
-                lock (d3dContext)
+                lock (context)
                 {
                     var subresourceIndex = CalculateSubresourceIndex(arraySlice, level);
 
@@ -113,13 +113,13 @@ namespace Microsoft.Xna.Framework.Graphics
                     var elementsInRow = rect.Width;
                     var rows = rect.Height;
                     var region = new ResourceRegion(rect.Left, rect.Top, 0, rect.Right, rect.Bottom, 1);
-                    d3dContext.CopySubresourceRegion(GetTexture(), subresourceIndex, region, stagingTex, 0);
+                    context._d3dContext.CopySubresourceRegion(GetTexture(), subresourceIndex, region, stagingTex, 0);
 
                     // Copy the data to the array.
                     DataStream stream = null;
                     try
                     {
-                        var databox = d3dContext.MapSubresource(stagingTex, 0, MapMode.Read, MapFlags.None, out stream);
+                        var databox = context._d3dContext.MapSubresource(stagingTex, 0, MapMode.Read, MapFlags.None, out stream);
 
                         var elementSize = _format.GetSize();
                         if (_format.IsCompressedFormat())

--- a/MonoGame.Framework/Graphics/Texture2D.DirectX.cs
+++ b/MonoGame.Framework/Graphics/Texture2D.DirectX.cs
@@ -65,7 +65,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 
                 // TODO: We need to deal with threaded contexts here!
                 var subresourceIndex = CalculateSubresourceIndex(arraySlice, level);
-                var d3dContext = GraphicsDevice._d3dContext;
+                var d3dContext = GraphicsDevice.Context;
                 lock (d3dContext)
                     d3dContext.UpdateSubresource(GetTexture(), subresourceIndex, region, dataPtr, GetPitch(rect.Width), 0);
             }
@@ -102,7 +102,7 @@ namespace Microsoft.Xna.Framework.Graphics
             // Save sampling description.
             _sampleDescription = desc.SampleDescription;
 
-            var d3dContext = GraphicsDevice._d3dContext;
+            var d3dContext = GraphicsDevice.Context;
             using (var stagingTex = new SharpDX.Direct3D11.Texture2D(GraphicsDevice._d3dDevice, desc))
             {
                 lock (d3dContext)

--- a/MonoGame.Framework/Graphics/Texture3D.DirectX.cs
+++ b/MonoGame.Framework/Graphics/Texture3D.DirectX.cs
@@ -77,7 +77,7 @@ namespace Microsoft.Xna.Framework.Graphics
 
                 var region = new ResourceRegion(left, top, front, right, bottom, back);
 
-                var d3dContext = GraphicsDevice._d3dContext;
+                var d3dContext = GraphicsDevice.Context;
                 lock (d3dContext)
                     d3dContext.UpdateSubresource(box, GetTexture(), subresourceIndex, region);
             }
@@ -109,7 +109,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 OptionFlags = ResourceOptionFlags.None,
             };
 
-            var d3dContext = GraphicsDevice._d3dContext;
+            var d3dContext = GraphicsDevice.Context;
             using (var stagingTex = new SharpDX.Direct3D11.Texture3D(GraphicsDevice._d3dDevice, desc))
             {
                 lock (d3dContext)

--- a/MonoGame.Framework/Graphics/Texture3D.DirectX.cs
+++ b/MonoGame.Framework/Graphics/Texture3D.DirectX.cs
@@ -77,9 +77,9 @@ namespace Microsoft.Xna.Framework.Graphics
 
                 var region = new ResourceRegion(left, top, front, right, bottom, back);
 
-                var d3dContext = GraphicsDevice.Context;
-                lock (d3dContext)
-                    d3dContext.UpdateSubresource(box, GetTexture(), subresourceIndex, region);
+                var context = GraphicsDevice.Context;
+                lock (context)
+                    context._d3dContext.UpdateSubresource(box, GetTexture(), subresourceIndex, region);
             }
             finally
             {
@@ -109,19 +109,19 @@ namespace Microsoft.Xna.Framework.Graphics
                 OptionFlags = ResourceOptionFlags.None,
             };
 
-            var d3dContext = GraphicsDevice.Context;
+            var context = GraphicsDevice.Context;
             using (var stagingTex = new SharpDX.Direct3D11.Texture3D(GraphicsDevice._d3dDevice, desc))
             {
-                lock (d3dContext)
+                lock (context)
                 {
                     // Copy the data from the GPU to the staging texture.
-                    d3dContext.CopySubresourceRegion(GetTexture(), level, new ResourceRegion(left, top, front, right, bottom, back), stagingTex, 0);
+                    context._d3dContext.CopySubresourceRegion(GetTexture(), level, new ResourceRegion(left, top, front, right, bottom, back), stagingTex, 0);
 
                     // Copy the data to the array.
                     DataStream stream = null;
                     try
                     {
-                        var databox = d3dContext.MapSubresource(stagingTex, 0, MapMode.Read, MapFlags.None, out stream);
+                        var databox = context._d3dContext.MapSubresource(stagingTex, 0, MapMode.Read, MapFlags.None, out stream);
 
                         // Some drivers may add pitch to rows or slices.
                         // We need to copy each row separatly and skip trailing zeros.

--- a/MonoGame.Framework/Graphics/TextureCollection.DirectX.cs
+++ b/MonoGame.Framework/Graphics/TextureCollection.DirectX.cs
@@ -16,15 +16,15 @@ namespace Microsoft.Xna.Framework.Graphics
                 return;
 
             if (_applyToVertexStage)
-                ClearTargets(targets, device.Context.VertexShader);
+                ClearTargets(targets, device.Context._d3dContext.VertexShader);
             else
-                ClearTargets(targets, device.Context.PixelShader);
+                ClearTargets(targets, device.Context._d3dContext.PixelShader);
         }
 
         private void ClearTargets(RenderTargetBinding[] targets, SharpDX.Direct3D11.CommonShaderStage shaderStage)
         {
             // NOTE: We make the assumption here that the caller has
-            // locked the d3dContext for us to use.
+            // locked the GraphicsContext for us to use.
 
             // We assume 4 targets to avoid a loop within a loop below.
             var target0 = targets[0].RenderTarget;
@@ -62,12 +62,12 @@ namespace Microsoft.Xna.Framework.Graphics
                 return;
 
             // NOTE: We make the assumption here that the caller has
-            // locked the d3dContext for us to use.
+            // locked the GraphicsContext for us to use.
             SharpDX.Direct3D11.CommonShaderStage shaderStage;
             if (_applyToVertexStage)
-                shaderStage = device.Context.VertexShader;
+                shaderStage = device.Context._d3dContext.VertexShader;
             else
-                shaderStage = device.Context.PixelShader;
+                shaderStage = device.Context._d3dContext.PixelShader;
 
             for (var i = 0; i < _textures.Length; i++)
             {

--- a/MonoGame.Framework/Graphics/TextureCollection.DirectX.cs
+++ b/MonoGame.Framework/Graphics/TextureCollection.DirectX.cs
@@ -16,9 +16,9 @@ namespace Microsoft.Xna.Framework.Graphics
                 return;
 
             if (_applyToVertexStage)
-                ClearTargets(targets, device._d3dContext.VertexShader);
+                ClearTargets(targets, device.Context.VertexShader);
             else
-                ClearTargets(targets, device._d3dContext.PixelShader);
+                ClearTargets(targets, device.Context.PixelShader);
         }
 
         private void ClearTargets(RenderTargetBinding[] targets, SharpDX.Direct3D11.CommonShaderStage shaderStage)
@@ -65,9 +65,9 @@ namespace Microsoft.Xna.Framework.Graphics
             // locked the d3dContext for us to use.
             SharpDX.Direct3D11.CommonShaderStage shaderStage;
             if (_applyToVertexStage)
-                shaderStage = device._d3dContext.VertexShader;
+                shaderStage = device.Context.VertexShader;
             else
-                shaderStage = device._d3dContext.PixelShader;
+                shaderStage = device.Context.PixelShader;
 
             for (var i = 0; i < _textures.Length; i++)
             {

--- a/MonoGame.Framework/Graphics/TextureCube.DirectX.cs
+++ b/MonoGame.Framework/Graphics/TextureCube.DirectX.cs
@@ -76,23 +76,23 @@ namespace Microsoft.Xna.Framework.Graphics
                 OptionFlags = ResourceOptionFlags.None,
             };
 
-            var d3dContext = GraphicsDevice.Context;
+            var context = GraphicsDevice.Context;
             using (var stagingTex = new SharpDX.Direct3D11.Texture2D(GraphicsDevice._d3dDevice, desc))
             {
-                lock (d3dContext)
+                lock (context)
                 {
                     // Copy the data from the GPU to the staging texture.
                     var subresourceIndex = CalculateSubresourceIndex(cubeMapFace, level);
                     var elementsInRow = rect.Width;
                     var rows = rect.Height;
                     var region = new ResourceRegion(rect.Left, rect.Top, 0, rect.Right, rect.Bottom, 1);
-                    d3dContext.CopySubresourceRegion(GetTexture(), subresourceIndex, region, stagingTex, 0);
+                    context._d3dContext.CopySubresourceRegion(GetTexture(), subresourceIndex, region, stagingTex, 0);
 
                     // Copy the data to the array.
                     DataStream stream = null;
                     try
                     {
-                        var databox = d3dContext.MapSubresource(stagingTex, 0, MapMode.Read, MapFlags.None, out stream);
+                        var databox = context._d3dContext.MapSubresource(stagingTex, 0, MapMode.Read, MapFlags.None, out stream);
 
                         var elementSize = _format.GetSize();
                         if (_format.IsCompressedFormat())
@@ -155,9 +155,9 @@ namespace Microsoft.Xna.Framework.Graphics
                     Right = rect.Right
                 };
 
-                var d3dContext = GraphicsDevice.Context;
-                lock (d3dContext)
-                    d3dContext.UpdateSubresource(box, GetTexture(), subresourceIndex, region);
+                var context = GraphicsDevice.Context;
+                lock (context)
+                    context._d3dContext.UpdateSubresource(box, GetTexture(), subresourceIndex, region);
             }
             finally
             {

--- a/MonoGame.Framework/Graphics/TextureCube.DirectX.cs
+++ b/MonoGame.Framework/Graphics/TextureCube.DirectX.cs
@@ -76,7 +76,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 OptionFlags = ResourceOptionFlags.None,
             };
 
-            var d3dContext = GraphicsDevice._d3dContext;
+            var d3dContext = GraphicsDevice.Context;
             using (var stagingTex = new SharpDX.Direct3D11.Texture2D(GraphicsDevice._d3dDevice, desc))
             {
                 lock (d3dContext)
@@ -155,7 +155,7 @@ namespace Microsoft.Xna.Framework.Graphics
                     Right = rect.Right
                 };
 
-                var d3dContext = GraphicsDevice._d3dContext;
+                var d3dContext = GraphicsDevice.Context;
                 lock (d3dContext)
                     d3dContext.UpdateSubresource(box, GetTexture(), subresourceIndex, region);
             }

--- a/MonoGame.Framework/Graphics/Vertices/IndexBuffer.DirectX.cs
+++ b/MonoGame.Framework/Graphics/Vertices/IndexBuffer.DirectX.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Xna.Framework.Graphics
             }
             else
             {
-                var deviceContext = GraphicsDevice.Context;
+                var context = GraphicsDevice.Context;
 
                 // Copy the texture to a staging resource
                 var stagingDesc = _buffer.Description;
@@ -80,7 +80,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 using (var stagingBuffer = new SharpDX.Direct3D11.Buffer(GraphicsDevice._d3dDevice, stagingDesc))
                 {
                     lock (GraphicsDevice.Context)
-                        deviceContext.CopyResource(_buffer, stagingBuffer);
+                        context._d3dContext.CopyResource(_buffer, stagingBuffer);
 
                     int TsizeInBytes = SharpDX.Utilities.SizeOf<T>();
                     var dataHandle = GCHandle.Alloc(data, GCHandleType.Pinned);
@@ -93,12 +93,12 @@ namespace Microsoft.Xna.Framework.Graphics
                         lock (GraphicsDevice.Context)
                         {
                             // Map the staging resource to a CPU accessible memory
-                            var box = deviceContext.MapSubresource(stagingBuffer, 0, SharpDX.Direct3D11.MapMode.Read, SharpDX.Direct3D11.MapFlags.None);
+                            var box = context._d3dContext.MapSubresource(stagingBuffer, 0, SharpDX.Direct3D11.MapMode.Read, SharpDX.Direct3D11.MapFlags.None);
 
                             SharpDX.Utilities.CopyMemory(dataPtr, box.DataPointer + offsetInBytes, elementCount * TsizeInBytes);
 
                             // Make sure that we unmap the resource in case of an exception
-                            deviceContext.UnmapSubresource(stagingBuffer, 0);
+                            context._d3dContext.UnmapSubresource(stagingBuffer, 0);
                         }
                     }
                     finally
@@ -120,13 +120,13 @@ namespace Microsoft.Xna.Framework.Graphics
                 if ((options & SetDataOptions.NoOverwrite) == SetDataOptions.NoOverwrite)
                     mode = SharpDX.Direct3D11.MapMode.WriteNoOverwrite;
 
-                var d3dContext = GraphicsDevice.Context;
-                lock (d3dContext)
+                var context = GraphicsDevice.Context;
+                lock (context)
                 {
-                    var dataBox = d3dContext.MapSubresource(_buffer, 0, mode, SharpDX.Direct3D11.MapFlags.None);
+                    var dataBox = context._d3dContext.MapSubresource(_buffer, 0, mode, SharpDX.Direct3D11.MapFlags.None);
                     SharpDX.Utilities.Write(IntPtr.Add(dataBox.DataPointer, offsetInBytes), data, startIndex,
                                             elementCount);
-                    d3dContext.UnmapSubresource(_buffer, 0);
+                    context._d3dContext.UnmapSubresource(_buffer, 0);
                 }
             }
             else
@@ -149,9 +149,9 @@ namespace Microsoft.Xna.Framework.Graphics
                     region.Right = offsetInBytes + (elementCount * elementSizeInBytes);
 
                     // TODO: We need to deal with threaded contexts here!
-                    var d3dContext = GraphicsDevice.Context;
-                    lock (d3dContext)
-                        d3dContext.UpdateSubresource(box, _buffer, 0, region);
+                    var context = GraphicsDevice.Context;
+                    lock (context)
+                        context._d3dContext.UpdateSubresource(box, _buffer, 0, region);
                 }
                 finally
                 {

--- a/MonoGame.Framework/Graphics/Vertices/IndexBuffer.DirectX.cs
+++ b/MonoGame.Framework/Graphics/Vertices/IndexBuffer.DirectX.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Xna.Framework.Graphics
             }
             else
             {
-                var deviceContext = GraphicsDevice._d3dContext;
+                var deviceContext = GraphicsDevice.Context;
 
                 // Copy the texture to a staging resource
                 var stagingDesc = _buffer.Description;
@@ -79,7 +79,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 stagingDesc.OptionFlags = SharpDX.Direct3D11.ResourceOptionFlags.None;
                 using (var stagingBuffer = new SharpDX.Direct3D11.Buffer(GraphicsDevice._d3dDevice, stagingDesc))
                 {
-                    lock (GraphicsDevice._d3dContext)
+                    lock (GraphicsDevice.Context)
                         deviceContext.CopyResource(_buffer, stagingBuffer);
 
                     int TsizeInBytes = SharpDX.Utilities.SizeOf<T>();
@@ -90,7 +90,7 @@ namespace Microsoft.Xna.Framework.Graphics
                         var dataPtr = (IntPtr)(dataHandle.AddrOfPinnedObject().ToInt64() + startBytes);
                         SharpDX.DataPointer DataPointer = new SharpDX.DataPointer(dataPtr, elementCount * TsizeInBytes);
 
-                        lock (GraphicsDevice._d3dContext)
+                        lock (GraphicsDevice.Context)
                         {
                             // Map the staging resource to a CPU accessible memory
                             var box = deviceContext.MapSubresource(stagingBuffer, 0, SharpDX.Direct3D11.MapMode.Read, SharpDX.Direct3D11.MapFlags.None);
@@ -120,7 +120,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 if ((options & SetDataOptions.NoOverwrite) == SetDataOptions.NoOverwrite)
                     mode = SharpDX.Direct3D11.MapMode.WriteNoOverwrite;
 
-                var d3dContext = GraphicsDevice._d3dContext;
+                var d3dContext = GraphicsDevice.Context;
                 lock (d3dContext)
                 {
                     var dataBox = d3dContext.MapSubresource(_buffer, 0, mode, SharpDX.Direct3D11.MapFlags.None);
@@ -149,7 +149,7 @@ namespace Microsoft.Xna.Framework.Graphics
                     region.Right = offsetInBytes + (elementCount * elementSizeInBytes);
 
                     // TODO: We need to deal with threaded contexts here!
-                    var d3dContext = GraphicsDevice._d3dContext;
+                    var d3dContext = GraphicsDevice.Context;
                     lock (d3dContext)
                         d3dContext.UpdateSubresource(box, _buffer, 0, region);
                 }

--- a/MonoGame.Framework/Graphics/Vertices/VertexBuffer.DirectX.cs
+++ b/MonoGame.Framework/Graphics/Vertices/VertexBuffer.DirectX.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Xna.Framework.Graphics
             }
             else
             {
-                var deviceContext = GraphicsDevice.Context;
+                var context = GraphicsDevice.Context;
 
                 // Copy the buffer to a staging resource
                 var stagingDesc = _buffer.Description;
@@ -78,7 +78,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 using (var stagingBuffer = new SharpDX.Direct3D11.Buffer(GraphicsDevice._d3dDevice, stagingDesc))
                 {
                     lock (GraphicsDevice.Context)
-                        deviceContext.CopyResource(_buffer, stagingBuffer);
+                        context._d3dContext.CopyResource(_buffer, stagingBuffer);
 
                     int TsizeInBytes = SharpDX.Utilities.SizeOf<T>();
                     var dataHandle = GCHandle.Alloc(data, GCHandleType.Pinned);
@@ -90,7 +90,7 @@ namespace Microsoft.Xna.Framework.Graphics
                         lock (GraphicsDevice.Context)
                         {
                             // Map the staging resource to a CPU accessible memory
-                            var box = deviceContext.MapSubresource(stagingBuffer, 0, SharpDX.Direct3D11.MapMode.Read, SharpDX.Direct3D11.MapFlags.None);
+                            var box = context._d3dContext.MapSubresource(stagingBuffer, 0, SharpDX.Direct3D11.MapMode.Read, SharpDX.Direct3D11.MapFlags.None);
 
                             if (vertexStride == TsizeInBytes)
                             {
@@ -103,7 +103,7 @@ namespace Microsoft.Xna.Framework.Graphics
                             }
 
                             // Make sure that we unmap the resource in case of an exception
-                            deviceContext.UnmapSubresource(stagingBuffer, 0);
+                            context._d3dContext.UnmapSubresource(stagingBuffer, 0);
                         }
                     }
                     finally
@@ -125,10 +125,10 @@ namespace Microsoft.Xna.Framework.Graphics
                 if ((options & SetDataOptions.NoOverwrite) == SetDataOptions.NoOverwrite)
                     mode = SharpDX.Direct3D11.MapMode.WriteNoOverwrite;
 
-                var d3dContext = GraphicsDevice.Context;
-                lock (d3dContext)
+                var context = GraphicsDevice.Context;
+                lock (context)
                 {
-                    var dataBox = d3dContext.MapSubresource(_buffer, 0, mode, SharpDX.Direct3D11.MapFlags.None);
+                    var dataBox = context._d3dContext.MapSubresource(_buffer, 0, mode, SharpDX.Direct3D11.MapFlags.None);
                     if (vertexStride == elementSizeInBytes)
 					{
                         SharpDX.Utilities.Write(dataBox.DataPointer + offsetInBytes, data, startIndex, elementCount);
@@ -139,7 +139,7 @@ namespace Microsoft.Xna.Framework.Graphics
                             SharpDX.Utilities.Write(dataBox.DataPointer + offsetInBytes + i * vertexStride, data, startIndex + i, 1);
                     }
 
-                    d3dContext.UnmapSubresource(_buffer, 0);
+                    context._d3dContext.UnmapSubresource(_buffer, 0);
                 }
             }
             else
@@ -150,7 +150,7 @@ namespace Microsoft.Xna.Framework.Graphics
                     var startBytes = startIndex * elementSizeInBytes;
                     var dataPtr = (IntPtr)(dataHandle.AddrOfPinnedObject().ToInt64() + startBytes);
 
-                    var d3dContext = GraphicsDevice.Context;
+                    var context = GraphicsDevice.Context;
 
                     if (vertexStride == elementSizeInBytes)
                     {
@@ -164,8 +164,8 @@ namespace Microsoft.Xna.Framework.Graphics
                         region.Left = offsetInBytes;
                         region.Right = offsetInBytes + (elementCount * elementSizeInBytes);
 
-                        lock (d3dContext)
-                            d3dContext.UpdateSubresource(box, _buffer, 0, region);
+                        lock (context)
+                            context._d3dContext.UpdateSubresource(box, _buffer, 0, region);
                     }
                     else
                     {
@@ -177,12 +177,12 @@ namespace Microsoft.Xna.Framework.Graphics
                         stagingDesc.OptionFlags = SharpDX.Direct3D11.ResourceOptionFlags.None;
                         using (var stagingBuffer = new SharpDX.Direct3D11.Buffer(GraphicsDevice._d3dDevice, stagingDesc))
                         {
-                            lock (d3dContext)
+                            lock (context)
                             {
-                                d3dContext.CopyResource(_buffer, stagingBuffer);
+                                context._d3dContext.CopyResource(_buffer, stagingBuffer);
 
                                 // Map the staging resource to a CPU accessible memory
-                                var box = d3dContext.MapSubresource(stagingBuffer, 0, SharpDX.Direct3D11.MapMode.Read,
+                                var box = context._d3dContext.MapSubresource(stagingBuffer, 0, SharpDX.Direct3D11.MapMode.Read,
                                     SharpDX.Direct3D11.MapFlags.None);
 
                                 for (int i = 0; i < elementCount; i++)
@@ -191,10 +191,10 @@ namespace Microsoft.Xna.Framework.Graphics
                                         dataPtr + i * elementSizeInBytes, elementSizeInBytes);
 
                                 // Make sure that we unmap the resource in case of an exception
-                                d3dContext.UnmapSubresource(stagingBuffer, 0);
+                                context._d3dContext.UnmapSubresource(stagingBuffer, 0);
 
                                 // Copy back from staging resource to real buffer.
-                                d3dContext.CopyResource(stagingBuffer, _buffer);
+                                context._d3dContext.CopyResource(stagingBuffer, _buffer);
                             }
                         }
                     }

--- a/MonoGame.Framework/Graphics/Vertices/VertexBuffer.DirectX.cs
+++ b/MonoGame.Framework/Graphics/Vertices/VertexBuffer.DirectX.cs
@@ -67,7 +67,7 @@ namespace Microsoft.Xna.Framework.Graphics
             }
             else
             {
-                var deviceContext = GraphicsDevice._d3dContext;
+                var deviceContext = GraphicsDevice.Context;
 
                 // Copy the buffer to a staging resource
                 var stagingDesc = _buffer.Description;
@@ -77,7 +77,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 stagingDesc.OptionFlags = SharpDX.Direct3D11.ResourceOptionFlags.None;
                 using (var stagingBuffer = new SharpDX.Direct3D11.Buffer(GraphicsDevice._d3dDevice, stagingDesc))
                 {
-                    lock (GraphicsDevice._d3dContext)
+                    lock (GraphicsDevice.Context)
                         deviceContext.CopyResource(_buffer, stagingBuffer);
 
                     int TsizeInBytes = SharpDX.Utilities.SizeOf<T>();
@@ -87,7 +87,7 @@ namespace Microsoft.Xna.Framework.Graphics
                         var startBytes = startIndex * vertexStride;
                         var dataPtr = (IntPtr)(dataHandle.AddrOfPinnedObject().ToInt64() + startBytes);
 
-                        lock (GraphicsDevice._d3dContext)
+                        lock (GraphicsDevice.Context)
                         {
                             // Map the staging resource to a CPU accessible memory
                             var box = deviceContext.MapSubresource(stagingBuffer, 0, SharpDX.Direct3D11.MapMode.Read, SharpDX.Direct3D11.MapFlags.None);
@@ -125,7 +125,7 @@ namespace Microsoft.Xna.Framework.Graphics
                 if ((options & SetDataOptions.NoOverwrite) == SetDataOptions.NoOverwrite)
                     mode = SharpDX.Direct3D11.MapMode.WriteNoOverwrite;
 
-                var d3dContext = GraphicsDevice._d3dContext;
+                var d3dContext = GraphicsDevice.Context;
                 lock (d3dContext)
                 {
                     var dataBox = d3dContext.MapSubresource(_buffer, 0, mode, SharpDX.Direct3D11.MapFlags.None);
@@ -150,7 +150,7 @@ namespace Microsoft.Xna.Framework.Graphics
                     var startBytes = startIndex * elementSizeInBytes;
                     var dataPtr = (IntPtr)(dataHandle.AddrOfPinnedObject().ToInt64() + startBytes);
 
-                    var d3dContext = GraphicsDevice._d3dContext;
+                    var d3dContext = GraphicsDevice.Context;
 
                     if (vertexStride == elementSizeInBytes)
                     {

--- a/MonoGame.Framework/Windows/WinFormsGameWindow.cs
+++ b/MonoGame.Framework/Windows/WinFormsGameWindow.cs
@@ -354,7 +354,6 @@ namespace MonoGame.Framework
             // This is critical for some NUnit runners which
             // typically will run all the tests on the same
             // process/thread.
-#if DEBUG
             var msg = new NativeMessage();
             do
             {
@@ -364,7 +363,6 @@ namespace MonoGame.Framework
                 Thread.Sleep(100);
             } 
             while (PeekMessage(out msg, IntPtr.Zero, 0, 1 << 5, 1));
-#endif
         }
 
         public void CenterForm()

--- a/MonoGame.Framework/iOS/iOSGameView.cs
+++ b/MonoGame.Framework/iOS/iOSGameView.cs
@@ -153,7 +153,7 @@ namespace Microsoft.Xna.Framework {
 		//        GraphicsContext into an iOS-specific GraphicsDevice.
 		//        Some level of cooperation with the UIView/Layer will
 		//        probably always be necessary, unfortunately.
-		private GraphicsContext __renderbuffergraphicsContext;
+		private OpenTK.Graphics.GraphicsContext __renderbuffergraphicsContext;
 		private IOpenGLApi _glapi;
 		private void CreateContext ()
 		{
@@ -179,10 +179,10 @@ namespace Microsoft.Xna.Framework {
 			//var version = Version.Parse (strVersion);
 
 			try {
-				__renderbuffergraphicsContext = new GraphicsContext (null, null, 2, 0, GraphicsContextFlags.Embedded);
+				__renderbuffergraphicsContext = new OpenTK.Graphics.GraphicsContext(null, null, 2, 0, GraphicsContextFlags.Embedded);
 				_glapi = new Gles20Api ();
 			} catch {
-				__renderbuffergraphicsContext = new GraphicsContext (null, null, 1, 1, GraphicsContextFlags.Embedded);
+				__renderbuffergraphicsContext = new OpenTK.Graphics.GraphicsContext(null, null, 1, 1, GraphicsContextFlags.Embedded);
 				_glapi = new Gles11Api ();
 			}
 

--- a/Test/Framework/Audio/SoundEffectInstanceXAudioTest.cs
+++ b/Test/Framework/Audio/SoundEffectInstanceXAudioTest.cs
@@ -1,0 +1,46 @@
+﻿using Microsoft.Xna.Framework.Audio;
+using NUnit.Framework;
+
+namespace MonoGame.Tests.Audio
+{
+    // Tests specific to SoundEffectInstance.XAudio (Windows DirectX)
+    public class SoundEffectInstanceXAudioTest
+    {
+        // Mono source
+        [TestCase( 0f, 1f, 1, 1f, 1f)]
+        [TestCase(-1f, 1f, 1, 1f, 0f)]
+        [TestCase( 1f, 1f, 1, 0f, 1f)]
+        [TestCase(-0.75f, 1f, 1, 1f, 0.25f)]
+        [TestCase( 0.75f, 1f, 1, 0.25f, 1f)]
+        [TestCase( 0f, 0.75f, 1, 0.75f, 0.75f)]
+        // Mono source, scaled
+        [TestCase(0f, 0.75f, 1, 0.75f, 0.75f)]
+        [TestCase(-1f, 0.75f, 1, 0.75f, 0f)]
+        [TestCase( 1f, 0.75f, 1, 0f, 0.75f)]
+        // Stereo source
+        [TestCase(0f, 1f, 2, 1f, 0f, 0f, 1f)]
+        [TestCase(-1f, 1f, 2, 0.5f, 0.5f, 0f, 0f)]
+        [TestCase(1f, 1f, 2, 0f, 0f, 0.5f, 0.5f)]
+        [TestCase(-0.5f, 1f, 2, 0.75f, 0.25f, 0f, 0.5f)]
+        [TestCase(0.5f, 1f, 2, 0.5f, 0f, 0.25f, 0.75f)]
+        [TestCase(-0.75f, 1f, 2, 0.625f, 0.375f, 0f, 0.25f)]
+        [TestCase(0.75f, 1f, 2, 0.25f, 0f, 0.375f, 0.625f)]
+        // Stereo source, scaled
+        [TestCase(0f, 0.75f, 2, 0.75f, 0f, 0f, 0.75f)]
+        [TestCase(-1f, 0.75f, 2, 0.375f, 0.375f, 0f, 0f)]
+        [TestCase(1f, 0.75f, 2, 0f, 0f, 0.375f, 0.375f)]
+        public void CalculateOutputMatrixReturnsExpectedResults(
+            float pan, float scale, int inputChannels,
+            params float[] expectedValues)
+        {
+            var outputMatrix = SoundEffectInstance.CalculateOutputMatrix(pan, scale, inputChannels);
+
+            for (int i = 0; i < expectedValues.Length; i++)
+                Assert.AreEqual(expectedValues[i], outputMatrix[i], "Channel#" + i);
+
+            // the remaining values should be 0
+            for (int i = expectedValues.Length; i < outputMatrix.Length; i++)
+                Assert.AreEqual(0f, outputMatrix[i], "Channel#" + i);
+        }
+    }
+}

--- a/Test/Framework/Graphics/GraphicsDeviceManagerTest.cs
+++ b/Test/Framework/Graphics/GraphicsDeviceManagerTest.cs
@@ -326,7 +326,7 @@ namespace MonoGame.Tests.Graphics
     internal class GraphicsDeviceManagerFixtureTest : GraphicsDeviceTestFixtureBase
     {
         [Test]
-        public void ResettingDeviceTriggersGdmEvents()
+        public void ResettingDeviceTriggersResetEvents()
         {
             var resetCount = 0;
             var resettingCount = 0;
@@ -344,6 +344,29 @@ namespace MonoGame.Tests.Graphics
 
             Assert.AreEqual(1, resetCount);
             Assert.AreEqual(1, resettingCount);
+        }
+        
+        [Test]
+        public void NewDeviceDoesNotTriggerReset()
+        {
+            var resetCount = 0;
+            var devLostCount = 0;
+
+            gd.DeviceReset += (sender, args) =>
+            {
+                resetCount++;
+            };
+            gd.DeviceLost += (sender, args) =>
+            {
+                devLostCount++;
+            };
+
+            // changing the profile requires creating a new device
+            gdm.GraphicsProfile = GraphicsProfile.Reach;
+            gdm.ApplyChanges();
+
+            Assert.AreEqual(0, resetCount);
+            Assert.AreEqual(0, devLostCount);
         }
 
         [Test]

--- a/Test/Framework/Graphics/GraphicsDeviceTest.cs
+++ b/Test/Framework/Graphics/GraphicsDeviceTest.cs
@@ -68,8 +68,9 @@ namespace MonoGame.Tests.Graphics
         }
 
         [Test]
-        public void ResetInvokedBeforeDeviceLost()
+        public void ResetDoesNotTriggerDeviceLost()
         {
+            // TODO figure out exactly when a device is lost
             var resetCount = 0;
             var devLostCount = 0;
 
@@ -88,7 +89,7 @@ namespace MonoGame.Tests.Graphics
             gd.Reset();
 
             Assert.AreEqual(1, resetCount);
-            Assert.AreEqual(1, devLostCount);
+            Assert.AreEqual(0, devLostCount);
         }
 
         // TODO Make sure dynamic graphics resources are notified when graphics device is lost


### PR DESCRIPTION
Related to #4571.
Note that OpenGL allready had part of GraphicsContext as internal class. 


As a proof of concept I moved BlendState.

in GraphicsDevice, a call to this.PlatformApplyX() becomes this.Context.ApplyX(). 
The code from GraphicsDevice.PlatformApplyX() is moved to  GraphicsContext.PlatformApplyX().
Common code and check for Dirty flags is moved to GraphicsContext.ApplyX().

Thoughts? 
