### PR TITLE
Matrix.CreateReflection() normalizes/alters the *input* value

### DIFF
--- a/MonoGame.Framework/Matrix.cs
+++ b/MonoGame.Framework/Matrix.cs
@@ -1382,7 +1382,6 @@ namespace Microsoft.Xna.Framework
         {
             Plane plane;
             Plane.Normalize(ref value, out plane);
-            value.Normalize();
             float x = plane.Normal.X;
             float y = plane.Normal.Y;
             float z = plane.Normal.Z;


### PR DESCRIPTION
The normalized value is not used in the Method after that.
In the beginning it creates a normalized copy of the plane.