### PR TITLE
Throw InvalidContentException with error line number/position in ContentIdentity

### DIFF
--- a/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/ReflectiveSerializer.cs
+++ b/MonoGame.Framework.Content.Pipeline/Serialization/Intermediate/ReflectiveSerializer.cs
@@ -175,7 +175,7 @@ namespace Microsoft.Xna.Framework.Content.Pipeline.Serialization.Intermediate
                             continue;
                         
                         // We failed to find a required element.
-                        throw new InvalidContentException(string.Format("The Xml element `{0}` is required, but element `{1}` was found at line {2}:{3}. Try changing the element order or adding missing elements.", info.Attribute.ElementName, input.Xml.Name, ((IXmlLineInfo)input.Xml).LineNumber, ((IXmlLineInfo)input.Xml).LinePosition));
+                        throw input.NewInvalidContentException(null, "The Xml element `{0}` is required, but element `{1}` was found. Try changing the element order or adding missing elements.", info.Attribute.ElementName, input.Xml.Name);
                     }
                 }
 


### PR DESCRIPTION
Uses the existing NewInvalidContentException()
 method of ReflectiveSerializer. 
That method takes care to report the error linenumber/position by passing it in the ContentIdenity of InvalidContentException.

This results in a consisted error message from mgcb  tool.