### PR TITLE
Update Android SDK template

### DIFF
--- a/ProjectTemplates/VisualStudio2010/Android/AndroidApplication1.csproj
+++ b/ProjectTemplates/VisualStudio2010/Android/AndroidApplication1.csproj
@@ -63,6 +63,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+  <None Include="Properties\AndroidManifest.xml" />
     <None Include="Resources\AboutResources.txt" />
     <None Include="Assets\AboutAssets.txt" />
   </ItemGroup>

--- a/ProjectTemplates/VisualStudio2010/Android/AndroidApplication1.csproj
+++ b/ProjectTemplates/VisualStudio2010/Android/AndroidApplication1.csproj
@@ -16,7 +16,7 @@
     <AndroidApplication>true</AndroidApplication>
     <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
-    <AndroidSupportedAbis>armeabi-v7a%3bx86</AndroidSupportedAbis>
+    <AndroidSupportedAbis>armeabi-v7a;arm64-v8a;x86;x86_64</AndroidSupportedAbis>
     <AndroidStoreUncompressedFileExtensions>.m4a</AndroidStoreUncompressedFileExtensions>
     <MandroidI18n />
     <TargetFrameworkVersion>v4.4</TargetFrameworkVersion>

--- a/ProjectTemplates/VisualStudio2010/Android/AndroidApplication1.csproj
+++ b/ProjectTemplates/VisualStudio2010/Android/AndroidApplication1.csproj
@@ -48,7 +48,6 @@
   <ItemGroup>
     <Reference Include="Mono.Android" />
     <Reference Include="mscorlib" />
-    <Reference Include="OpenTK-1.0" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Xml.Linq" />

--- a/ProjectTemplates/VisualStudio2010/Android/MonoGameAndroid.vstemplate
+++ b/ProjectTemplates/VisualStudio2010/Android/MonoGameAndroid.vstemplate
@@ -24,6 +24,7 @@
       <ProjectItem ReplaceParameters="true" TargetFileName="Game1.cs">Game1.cs</ProjectItem>
       <Folder Name="Properties" TargetFolderName="Properties">
         <ProjectItem ReplaceParameters="true" TargetFileName="AssemblyInfo.cs">AssemblyInfo.cs</ProjectItem>
+        <ProjectItem ReplaceParameters="true" TargetFileName="AndroidManifest.xml">AndroidManifest.xml</ProjectItem>
       </Folder>
       <Folder Name="Resources" TargetFolderName="Resources">
         <ProjectItem ReplaceParameters="true" TargetFileName="AboutResources.txt">AboutResources.txt</ProjectItem>

--- a/ProjectTemplates/VisualStudio2010/Android/Properties/AndroidManifest.xml
+++ b/ProjectTemplates/VisualStudio2010/Android/Properties/AndroidManifest.xml
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="$projectname$.$projectname$" android:versionCode="1" android:versionName="1.0">
+	<uses-sdk/>
+	<application android:label="$projectname$"></application>
+</manifest>


### PR DESCRIPTION
This updates the old SDK template to be functional from VS2017 and later.
-Remove reference to OpenTK. MG now has it's own GL bindings and OpenTK is no longer required.
-Add Manifest file. The manifest file is not generated automatically, VS2017 fails to build with an error and the user had to open properties, go to manifest, and click 'Generate Manifest file'.
-Include the 64-bit ABIs by default. Google Play store requires both ARM/x86 and 32/64 builds.