### PR TITLE
Remove unnecessary check for _gameTimer

### DIFF
--- a/MonoGame.Framework/Game.cs
+++ b/MonoGame.Framework/Game.cs
@@ -536,11 +536,6 @@ namespace Microsoft.Xna.Framework
             }
 
             // Advance the accumulated elapsed time.
-            if (_gameTimer == null)
-            {
-                _gameTimer = new Stopwatch();
-                _gameTimer.Start();
-            }
             var currentTicks = _gameTimer.Elapsed.Ticks;
             _accumulatedElapsedTime += TimeSpan.FromTicks(currentTicks - _previousTicks);
             _previousTicks = currentTicks;


### PR DESCRIPTION
Remove unnecessary check for _gameTimer.
gameTimer is always initialized and started by the time Tick() is
called.